### PR TITLE
feat: SSH ProxyJump (jumphost/bastion) support

### DIFF
--- a/internal/hostmanager/manager.go
+++ b/internal/hostmanager/manager.go
@@ -23,6 +23,7 @@ type Input struct {
 	AuthType       string  `json:"auth_type" jsonschema:"认证方式：key 或 password"`
 	KeyID          *int64  `json:"key_id,omitempty" jsonschema:"key 认证使用的密钥 ID，auth_type=key 时必填"`
 	Password       *string `json:"password,omitempty" jsonschema:"登录密码；auth_type 为 password 时必填，只写不可读，审计中固定脱敏"`
+	ProxyJumpHost  *string `json:"proxy_jump_host,omitempty" jsonschema:"跳板机主机名，留空表示直连；引用 hosts_list 中已有的主机名，支持链式跳板"`
 	MonitorEnabled *bool   `json:"monitor_enabled,omitempty" jsonschema:"是否纳入后台资源监控轮询，新建时默认开启"`
 }
 
@@ -204,6 +205,22 @@ func (m *Manager) hostFromInput(ctx context.Context, old store.Host, in Input, u
 		}
 	default:
 		return store.Host{}, invalid("auth_type 必须是 key 或 password")
+	}
+	// ProxyJumpHost: 留空表示直连，非空时引用另一台主机作为跳板
+	if in.ProxyJumpHost != nil && strings.TrimSpace(*in.ProxyJumpHost) != "" {
+		jumpName := strings.TrimSpace(*in.ProxyJumpHost)
+		if jumpName == host.Name {
+			return store.Host{}, invalid("proxy_jump_host 不能引用自身")
+		}
+		if _, err := m.store.GetHostByName(ctx, jumpName); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return store.Host{}, invalid("跳板机主机 " + jumpName + " 不存在")
+			}
+			return store.Host{}, &Error{Kind: ErrorInternal, Err: err}
+		}
+		host.ProxyJumpHost = sql.NullString{String: jumpName, Valid: true}
+	} else {
+		host.ProxyJumpHost = sql.NullString{}
 	}
 	return host, nil
 }

--- a/internal/mcpserver/hosts.go
+++ b/internal/mcpserver/hosts.go
@@ -38,6 +38,7 @@ type HostUpdateInput struct {
 	AuthType       string  `json:"auth_type" jsonschema:"认证方式：key 或 password"`
 	KeyID          *int64  `json:"key_id,omitempty" jsonschema:"key 认证使用的密钥 ID，auth_type=key 时必填"`
 	Password       *string `json:"password,omitempty" jsonschema:"新的登录密码；auth_type 保持 password 且沿用原密码时可省略"`
+	ProxyJumpHost  *string `json:"proxy_jump_host,omitempty" jsonschema:"跳板机主机名，留空表示直连；引用已有主机名，支持链式跳板"`
 	MonitorEnabled *bool   `json:"monitor_enabled,omitempty" jsonschema:"是否纳入后台资源监控轮询，省略表示保持原值"`
 }
 
@@ -50,6 +51,7 @@ type ManagedHostItem struct {
 	AuthType       string  `json:"auth_type"`
 	KeyID          *int64  `json:"key_id"`
 	HostKeyFP      *string `json:"hostkey_fp"`
+	ProxyJumpHost  *string `json:"proxy_jump_host"`
 	MonitorEnabled bool    `json:"monitor_enabled"`
 	CreatedAt      int64   `json:"created_at"`
 	Online         bool    `json:"online"`
@@ -152,7 +154,7 @@ func (s *Server) hostUpdate(ctx context.Context, _ *mcp.CallToolRequest, in Host
 	}
 	updated, err := s.HostManager.Update(ctx, host.ID, hostmanager.Input{
 		Name: in.Name, Addr: in.Addr, Port: in.Port, Username: in.Username, AuthType: in.AuthType,
-		KeyID: in.KeyID, Password: in.Password, MonitorEnabled: in.MonitorEnabled,
+		KeyID: in.KeyID, Password: in.Password, ProxyJumpHost: in.ProxyJumpHost, MonitorEnabled: in.MonitorEnabled,
 	})
 	if err != nil {
 		return errorResult(err.Error()), ManagedHostItem{}, nil
@@ -218,7 +220,7 @@ func (s *Server) managedHostItem(host store.Host) ManagedHostItem {
 	view := host.View()
 	return ManagedHostItem{
 		ID: view.ID, Name: view.Name, Addr: view.Addr, Port: view.Port, Username: view.Username,
-		AuthType: view.AuthType, KeyID: view.KeyID, HostKeyFP: view.HostKeyFP,
+		AuthType: view.AuthType, KeyID: view.KeyID, HostKeyFP: view.HostKeyFP, ProxyJumpHost: view.ProxyJumpHost,
 		MonitorEnabled: view.MonitorEnabled, CreatedAt: view.CreatedAt, Online: s.Pool.IsOnline(host.Name),
 	}
 }

--- a/internal/memoryx/engine_test.go
+++ b/internal/memoryx/engine_test.go
@@ -46,7 +46,7 @@ func TestRememberDeduplicatesAndKeepsMaximumImportance(t *testing.T) {
 	st := newTestStore(t)
 	engine := New(st, EmbeddingConfig{})
 	bank := sql.NullInt64{Int64: 7, Valid: true}
-	if _, err := st.DB.ExecContext(ctx, `INSERT INTO hosts(id,name,addr,port,username,auth_type,monitor_enabled,created_at) VALUES(7,'host','127.0.0.1',22,'user','password',0,1)`); err != nil {
+	if _, err := st.DB.ExecContext(ctx, `INSERT INTO hosts(id,name,addr,port,username,auth_type,proxy_jump_host,monitor_enabled,created_at) VALUES(7,'host','127.0.0.1',22,'user','password',NULL,0,1)`); err != nil {
 		t.Fatal(err)
 	}
 	firstID, deduped, _, err := engine.Remember(ctx, RememberInput{HostID: bank, Content: "  部署目录在 /opt/app  ", Importance: 0.4})
@@ -69,7 +69,7 @@ func TestRememberDeduplicatesAndKeepsMaximumImportance(t *testing.T) {
 func TestRecallScoresImportanceAndRecency(t *testing.T) {
 	ctx := context.Background()
 	st := newTestStore(t)
-	engine := New(st, EmbeddingConfig{})
+	engine := New(st, EmbeddingConfig{})}
 	now := time.Now()
 	oldID := addTestMemory(t, st, store.Memory{Content: "nginx 配置说明 old", Importance: 1, CreatedAt: now.Add(-30 * 24 * time.Hour).Unix()})
 	newID := addTestMemory(t, st, store.Memory{Content: "nginx 配置说明 new", Importance: 0.05, CreatedAt: now.Unix()})
@@ -90,7 +90,7 @@ func TestRecallMergesHostAndGlobalWithoutCrossingBanks(t *testing.T) {
 	st := newTestStore(t)
 	engine := New(st, EmbeddingConfig{})
 	for id, name := range map[int64]string{1: "allowed", 2: "denied"} {
-		if _, err := st.DB.ExecContext(ctx, `INSERT INTO hosts(id,name,addr,port,username,auth_type,monitor_enabled,created_at) VALUES(?,?,?,22,'user','password',0,1)`, id, name, "127.0.0.1"); err != nil {
+		if _, err := st.DB.ExecContext(ctx, `INSERT INTO hosts(id,name,addr,port,username,auth_type,proxy_jump_host,monitor_enabled,created_at) VALUES(?,?,?,22,'user','password',NULL,0,1)`, id, name, "127.0.0.1"); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/sshpool/pool.go
+++ b/internal/sshpool/pool.go
@@ -97,14 +97,25 @@ func (p *Pool) dial(ctx context.Context, h store.Host) (*ssh.Client, error) {
 	if depth > maxJumpDepth {
 		return nil, fmt.Errorf("跳板链路过深（超过 %d 层），可能存在循环引用", maxJumpDepth)
 	}
-	var auth ssh.AuthMethod
+	var auths []ssh.AuthMethod
 	switch h.AuthType {
 	case "password":
 		plain, err := p.box.Open(h.PasswordEnc)
 		if err != nil {
 			return nil, err
 		}
-		auth = ssh.Password(string(plain))
+		// ESXi 等设备只接受 keyboard-interactive，不接受 password 方法。
+		// 同时提供两种 AuthMethod，Go SSH 客户端会自动选择服务器支持的方式。
+		password := string(plain)
+		auths = append(auths, ssh.Password(password), ssh.KeyboardInteractive(
+			func(name, instruction string, questions []string, echos []bool) ([]string, error) {
+				answers := make([]string, len(questions))
+				for i := range questions {
+					answers[i] = password
+				}
+				return answers, nil
+			},
+		))
 		for i := range plain {
 			plain[i] = 0
 		}
@@ -127,7 +138,7 @@ func (p *Pool) dial(ctx context.Context, h store.Host) (*ssh.Client, error) {
 		if err != nil {
 			return nil, fmt.Errorf("解析私钥: %w", err)
 		}
-		auth = ssh.PublicKeys(signer)
+		auths = append(auths, ssh.PublicKeys(signer))
 	default:
 		return nil, fmt.Errorf("不支持的认证类型 %q", h.AuthType)
 	}
@@ -144,7 +155,7 @@ func (p *Pool) dial(ctx context.Context, h store.Host) (*ssh.Client, error) {
 		}
 		return nil
 	}
-	config := &ssh.ClientConfig{User: h.Username, Auth: []ssh.AuthMethod{auth}, HostKeyCallback: callback, Timeout: 15 * time.Second}
+	config := &ssh.ClientConfig{User: h.Username, Auth: auths, HostKeyCallback: callback, Timeout: 15 * time.Second}
 	addr := net.JoinHostPort(h.Addr, strconv.Itoa(h.Port))
 	var conn net.Conn
 	var err error

--- a/internal/sshpool/pool.go
+++ b/internal/sshpool/pool.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -40,7 +41,33 @@ func (p *Pool) getEntry(name string) *entry {
 	}
 	return e
 }
+
+// jumpChainKey is used to detect circular proxy-jump references via context.
+type jumpChainKey struct{}
+
+func jumpChain(ctx context.Context) []string {
+	v, _ := ctx.Value(jumpChainKey{}).([]string)
+	return v
+}
+
+func withJump(ctx context.Context, name string) context.Context {
+	chain := jumpChain(ctx)
+	newChain := make([]string, len(chain), len(chain)+1)
+	copy(newChain, chain)
+	newChain = append(newChain, name)
+	return context.WithValue(ctx, jumpChainKey{}, newChain)
+}
+
 func (p *Pool) Get(ctx context.Context, name string) (*ssh.Client, error) {
+	// Check for circular proxy-jump before locking: if name already appears
+	// in the jump chain, its entry lock is held by a caller up the stack,
+	// so locking here would deadlock.
+	chain := jumpChain(ctx)
+	for _, n := range chain {
+		if n == name {
+			return nil, fmt.Errorf("跳板机循环引用: %s → %s", strings.Join(append(chain, name), " → "), name)
+		}
+	}
 	e := p.getEntry(name)
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -61,7 +88,15 @@ func (p *Pool) Get(ctx context.Context, name string) (*ssh.Client, error) {
 	go p.keepalive(name, e, client)
 	return client, nil
 }
+
+const maxJumpDepth = 5
+
 func (p *Pool) dial(ctx context.Context, h store.Host) (*ssh.Client, error) {
+	// Secondary defense: depth-based limit on jump chain length.
+	depth := len(jumpChain(ctx))
+	if depth > maxJumpDepth {
+		return nil, fmt.Errorf("跳板链路过深（超过 %d 层），可能存在循环引用", maxJumpDepth)
+	}
 	var auth ssh.AuthMethod
 	switch h.AuthType {
 	case "password":
@@ -111,10 +146,25 @@ func (p *Pool) dial(ctx context.Context, h store.Host) (*ssh.Client, error) {
 	}
 	config := &ssh.ClientConfig{User: h.Username, Auth: []ssh.AuthMethod{auth}, HostKeyCallback: callback, Timeout: 15 * time.Second}
 	addr := net.JoinHostPort(h.Addr, strconv.Itoa(h.Port))
-	d := net.Dialer{Timeout: 15 * time.Second}
-	conn, err := d.DialContext(ctx, "tcp", addr)
-	if err != nil {
-		return nil, fmt.Errorf("连接 %s: %w", nameAddr(h), err)
+	var conn net.Conn
+	var err error
+	if h.ProxyJumpHost.Valid && h.ProxyJumpHost.String != "" {
+		// Dial through a jump host: add current host to chain (for cycle detection)
+		// then recursively Get the jump host's SSH client (cached or freshly dialed).
+		jumpClient, err := p.Get(withJump(ctx, h.Name), h.ProxyJumpHost.String)
+		if err != nil {
+			return nil, fmt.Errorf("跳板机 %s: %w", h.ProxyJumpHost.String, err)
+		}
+		conn, err = jumpClient.Dial("tcp", addr)
+		if err != nil {
+			return nil, fmt.Errorf("经跳板机 %s 连接 %s: %w", h.ProxyJumpHost.String, nameAddr(h), err)
+		}
+	} else {
+		d := net.Dialer{Timeout: 15 * time.Second}
+		conn, err = d.DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return nil, fmt.Errorf("连接 %s: %w", nameAddr(h), err)
+		}
 	}
 	cc, chans, reqs, err := ssh.NewClientConn(conn, addr, config)
 	if err != nil {

--- a/internal/store/auth_sessions.go
+++ b/internal/store/auth_sessions.go
@@ -85,7 +85,7 @@ func (s *Store) findToken(ctx context.Context, hash, resource string, requireRes
 	t.AllHosts = all != 0
 	t.ManageHosts = manage != 0
 	_, _ = s.DB.ExecContext(ctx, `UPDATE tokens SET last_used_at=? WHERE id=?`, time.Now().Unix(), t.ID)
-	hostQuery := `SELECT h.id,h.name,h.addr,h.port,h.username,h.auth_type,h.key_id,h.password_enc,h.hostkey_fp,h.monitor_enabled,h.created_at FROM hosts h`
+	hostQuery := `SELECT h.id,h.name,h.addr,h.port,h.username,h.auth_type,h.key_id,h.password_enc,h.hostkey_fp,h.proxy_jump_host,h.monitor_enabled,h.created_at FROM hosts h`
 	hostArgs := []any{}
 	if !t.AllHosts {
 		hostQuery += ` JOIN token_hosts th ON th.host_id=h.id WHERE th.token_id=?`

--- a/internal/store/hosts_keys.go
+++ b/internal/store/hosts_keys.go
@@ -55,13 +55,13 @@ func (s *Store) DeleteKey(ctx context.Context, id int64) error {
 func scanHost(row interface{ Scan(...any) error }) (Host, error) {
 	var h Host
 	var enabled int
-	err := row.Scan(&h.ID, &h.Name, &h.Addr, &h.Port, &h.Username, &h.AuthType, &h.KeyID, &h.PasswordEnc, &h.HostKeyFP, &enabled, &h.CreatedAt)
+	err := row.Scan(&h.ID, &h.Name, &h.Addr, &h.Port, &h.Username, &h.AuthType, &h.KeyID, &h.PasswordEnc, &h.HostKeyFP, &h.ProxyJumpHost, &enabled, &h.CreatedAt)
 	h.MonitorEnabled = enabled != 0
 	return h, err
 }
 func (s *Store) CreateHost(ctx context.Context, h Host) (Host, error) {
 	now := time.Now().Unix()
-	res, err := s.DB.ExecContext(ctx, `INSERT INTO hosts(name,addr,port,username,auth_type,key_id,password_enc,monitor_enabled,created_at) VALUES(?,?,?,?,?,?,?,?,?)`, h.Name, h.Addr, h.Port, h.Username, h.AuthType, nullInt(h.KeyID), h.PasswordEnc, boolInt(h.MonitorEnabled), now)
+	res, err := s.DB.ExecContext(ctx, `INSERT INTO hosts(name,addr,port,username,auth_type,key_id,password_enc,proxy_jump_host,monitor_enabled,created_at) VALUES(?,?,?,?,?,?,?,?,?,?)`, h.Name, h.Addr, h.Port, h.Username, h.AuthType, nullInt(h.KeyID), h.PasswordEnc, nullStr(h.ProxyJumpHost), boolInt(h.MonitorEnabled), now)
 	if err != nil {
 		return Host{}, err
 	}
@@ -70,7 +70,7 @@ func (s *Store) CreateHost(ctx context.Context, h Host) (Host, error) {
 	return h, nil
 }
 func (s *Store) UpdateHost(ctx context.Context, h Host) error {
-	_, err := s.DB.ExecContext(ctx, `UPDATE hosts SET name=?,addr=?,port=?,username=?,auth_type=?,key_id=?,password_enc=?,monitor_enabled=? WHERE id=?`, h.Name, h.Addr, h.Port, h.Username, h.AuthType, nullInt(h.KeyID), h.PasswordEnc, boolInt(h.MonitorEnabled), h.ID)
+	_, err := s.DB.ExecContext(ctx, `UPDATE hosts SET name=?,addr=?,port=?,username=?,auth_type=?,key_id=?,password_enc=?,proxy_jump_host=?,monitor_enabled=? WHERE id=?`, h.Name, h.Addr, h.Port, h.Username, h.AuthType, nullInt(h.KeyID), h.PasswordEnc, nullStr(h.ProxyJumpHost), boolInt(h.MonitorEnabled), h.ID)
 	return err
 }
 func (s *Store) DeleteHost(ctx context.Context, id int64) error {
@@ -119,7 +119,7 @@ func (s *Store) DeleteHost(ctx context.Context, id int64) error {
 	return tx.Commit()
 }
 func (s *Store) ListHosts(ctx context.Context) ([]Host, error) {
-	rows, err := s.DB.QueryContext(ctx, `SELECT id,name,addr,port,username,auth_type,key_id,password_enc,hostkey_fp,monitor_enabled,created_at FROM hosts ORDER BY name`)
+	rows, err := s.DB.QueryContext(ctx, `SELECT id,name,addr,port,username,auth_type,key_id,password_enc,hostkey_fp,proxy_jump_host,monitor_enabled,created_at FROM hosts ORDER BY name`)
 	if err != nil {
 		return nil, err
 	}
@@ -135,10 +135,10 @@ func (s *Store) ListHosts(ctx context.Context) ([]Host, error) {
 	return out, rows.Err()
 }
 func (s *Store) GetHostByName(ctx context.Context, name string) (Host, error) {
-	return scanHost(s.DB.QueryRowContext(ctx, `SELECT id,name,addr,port,username,auth_type,key_id,password_enc,hostkey_fp,monitor_enabled,created_at FROM hosts WHERE name=?`, name))
+	return scanHost(s.DB.QueryRowContext(ctx, `SELECT id,name,addr,port,username,auth_type,key_id,password_enc,hostkey_fp,proxy_jump_host,monitor_enabled,created_at FROM hosts WHERE name=?`, name))
 }
 func (s *Store) GetHost(ctx context.Context, id int64) (Host, error) {
-	return scanHost(s.DB.QueryRowContext(ctx, `SELECT id,name,addr,port,username,auth_type,key_id,password_enc,hostkey_fp,monitor_enabled,created_at FROM hosts WHERE id=?`, id))
+	return scanHost(s.DB.QueryRowContext(ctx, `SELECT id,name,addr,port,username,auth_type,key_id,password_enc,hostkey_fp,proxy_jump_host,monitor_enabled,created_at FROM hosts WHERE id=?`, id))
 }
 func (s *Store) UpdateHostFingerprint(ctx context.Context, id int64, fp *string) error {
 	var v any
@@ -149,7 +149,7 @@ func (s *Store) UpdateHostFingerprint(ctx context.Context, id int64, fp *string)
 	return err
 }
 func (s *Store) MonitoredHosts(ctx context.Context) ([]Host, error) {
-	rows, err := s.DB.QueryContext(ctx, `SELECT id,name,addr,port,username,auth_type,key_id,password_enc,hostkey_fp,monitor_enabled,created_at FROM hosts WHERE monitor_enabled=1 ORDER BY name`)
+	rows, err := s.DB.QueryContext(ctx, `SELECT id,name,addr,port,username,auth_type,key_id,password_enc,hostkey_fp,proxy_jump_host,monitor_enabled,created_at FROM hosts WHERE monitor_enabled=1 ORDER BY name`)
 	if err != nil {
 		return nil, err
 	}
@@ -173,6 +173,13 @@ func boolInt(v bool) int {
 func nullInt(v sql.NullInt64) any {
 	if v.Valid {
 		return v.Int64
+	}
+	return nil
+}
+
+func nullStr(v sql.NullString) any {
+	if v.Valid {
+		return v.String
 	}
 	return nil
 }

--- a/internal/store/migrations/0007_proxy_jump.sql
+++ b/internal/store/migrations/0007_proxy_jump.sql
@@ -1,0 +1,4 @@
+-- Add proxy_jump_host column to support SSH ProxyJump (jumphost/bastion).
+-- Stores the host name of an intermediary jump host; NULL means direct connection.
+-- Chain is implicit: A.proxy_jump_host=B, B.proxy_jump_host=C → connect via C→B→A.
+ALTER TABLE hosts ADD COLUMN proxy_jump_host TEXT;

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -20,6 +20,7 @@ type Host struct {
 	KeyID          sql.NullInt64  `json:"-"`
 	PasswordEnc    []byte         `json:"-"`
 	HostKeyFP      sql.NullString `json:"-"`
+	ProxyJumpHost  sql.NullString `json:"-"` // 引用另一台主机的 name 作为跳板机
 	MonitorEnabled bool           `json:"monitor_enabled"`
 	CreatedAt      int64          `json:"created_at"`
 }
@@ -33,6 +34,7 @@ type HostView struct {
 	AuthType       string  `json:"auth_type"`
 	KeyID          *int64  `json:"key_id"`
 	HostKeyFP      *string `json:"hostkey_fp"`
+	ProxyJumpHost  *string `json:"proxy_jump_host"`
 	MonitorEnabled bool    `json:"monitor_enabled"`
 	CreatedAt      int64   `json:"created_at"`
 }
@@ -46,6 +48,10 @@ func (h Host) View() HostView {
 	if h.HostKeyFP.Valid {
 		x := h.HostKeyFP.String
 		v.HostKeyFP = &x
+	}
+	if h.ProxyJumpHost.Valid && h.ProxyJumpHost.String != "" {
+		x := h.ProxyJumpHost.String
+		v.ProxyJumpHost = &x
 	}
 	return v
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -29,6 +29,9 @@ var migration0005 string
 //go:embed migrations/0006_memories.sql
 var migration0006 string
 
+//go:embed migrations/0007_proxy_jump.sql
+var migration0007 string
+
 type Store struct{ DB *sql.DB }
 
 func Open(dataDir string) (*Store, error) {
@@ -71,6 +74,7 @@ func migrate(db *sql.DB) error {
 		{version: 4, sql: migration0004},
 		{version: 5, sql: migration0005},
 		{version: 6, sql: migration0006},
+		{version: 7, sql: migration0007},
 	} {
 		if err := applyMigration(db, m); err != nil {
 			return fmt.Errorf("版本 %d: %w", m.version, err)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -68,10 +68,10 @@ func TestOpenUpgradesLegacyDatabase(t *testing.T) {
 		}
 	}
 	var versions int
-	if err = st.DB.QueryRowContext(ctx, `SELECT count(*) FROM schema_migrations WHERE version IN (1,2,3,4,5,6)`).Scan(&versions); err != nil {
+	if err = st.DB.QueryRowContext(ctx, `SELECT count(*) FROM schema_migrations WHERE version IN (1,2,3,4,5,6,7)`).Scan(&versions); err != nil {
 		t.Fatal(err)
 	}
-	if versions != 6 {
+	if versions != 7 {
 		t.Fatalf("迁移版本数 = %d", versions)
 	}
 	if err = st.Close(); err != nil {
@@ -85,7 +85,7 @@ func TestOpenUpgradesLegacyDatabase(t *testing.T) {
 	if err = st.DB.QueryRowContext(ctx, `SELECT count(*) FROM schema_migrations`).Scan(&versions); err != nil {
 		t.Fatal(err)
 	}
-	if versions != 6 {
+	if versions != 7 {
 		t.Fatalf("二次迁移版本数 = %d", versions)
 	}
 }
@@ -114,7 +114,7 @@ func TestOpenRecordsPreexistingManageHostsColumn(t *testing.T) {
 	if err = st.DB.QueryRow(`SELECT count(*) FROM schema_migrations`).Scan(&versions); err != nil {
 		t.Fatal(err)
 	}
-	if versions != 6 {
+	if versions != 7 {
 		t.Fatalf("迁移登记数 = %d", versions)
 	}
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -9,6 +9,7 @@ export type Host = {
   auth_type: 'key' | 'password'
   key_id?: number
   hostkey_fp?: string
+  proxy_jump_host?: string
   monitor_enabled: boolean
   created_at: number
 }
@@ -115,6 +116,7 @@ export type HostPayload = {
   auth_type: 'key' | 'password'
   key_id?: number
   password?: string
+  proxy_jump_host?: string
   monitor_enabled: boolean
 }
 

--- a/web/src/components/host-connection.tsx
+++ b/web/src/components/host-connection.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { ArrowsClockwise } from '@phosphor-icons/react'
 import type { Host } from '@/api/types'
 
 /** 地址默认只做视觉脱敏；用户名与端口保留，便于在多台主机间快速辨认。 */
@@ -7,26 +8,34 @@ export function HostConnection({ host }: { host: Host }) {
   const connection = `${host.username}@${host.addr}:${host.port}`
 
   return (
-    <button
-      type="button"
-      onClick={() => setRevealed((value) => !value)}
-      aria-label={
-        revealed ? `${connection}，点击隐藏服务器地址` : `${host.name} 的服务器地址已隐藏，点击显示`
-      }
-      aria-pressed={revealed}
-      className="mt-0.5 inline-flex max-w-full min-w-0 items-center rounded-[4px] font-mono text-[12px] text-muted tabular-nums transition-colors hover:text-text"
-    >
-      <span className="truncate">
-        {host.username}@
-        <span
-          className={`inline-block transition-[filter] duration-200 ${
-            revealed ? '' : 'select-none blur-[4px]'
-          }`}
-        >
-          {host.addr}
+    <div className="mt-0.5 flex flex-col gap-0.5">
+      <button
+        type="button"
+        onClick={() => setRevealed((value) => !value)}
+        aria-label={
+          revealed ? `${connection}，点击隐藏服务器地址` : `${host.name} 的服务器地址已隐藏，点击显示`
+        }
+        aria-pressed={revealed}
+        className="inline-flex max-w-full min-w-0 items-center rounded-[4px] font-mono text-[12px] text-muted tabular-nums transition-colors hover:text-text"
+      >
+        <span className="truncate">
+          {host.username}@
+          <span
+            className={`inline-block transition-[filter] duration-200 ${
+              revealed ? '' : 'select-none blur-[4px]'
+            }`}
+          >
+            {host.addr}
+          </span>
+          :{host.port}
         </span>
-        :{host.port}
-      </span>
-    </button>
+      </button>
+      {host.proxy_jump_host ? (
+        <span className="inline-flex items-center gap-1 text-[11px] text-muted">
+          <ArrowsClockwise size={11} />
+          经 {host.proxy_jump_host} 跳板
+        </span>
+      ) : null}
+    </div>
   )
 }

--- a/web/src/pages/hosts.tsx
+++ b/web/src/pages/hosts.tsx
@@ -45,6 +45,7 @@ const emptyForm: HostPayload = {
   auth_type: 'password',
   password: undefined,
   key_id: undefined,
+  proxy_jump_host: undefined,
   monitor_enabled: true,
 }
 
@@ -433,6 +434,34 @@ export function HostsPage() {
             </Field>
           )}
 
+          {/* 跳板机选择：可选字段，从已有主机列表中选择，排除自身 */}
+          <Field
+            label="跳板机"
+            hint="留空表示直连；支持链式跳板"
+            className="sm:col-span-3"
+          >
+            {(id) => (
+              <Controller
+                name="proxy_jump_host"
+                control={control}
+                render={({ field }) => (
+                  <Select
+                    id={id}
+                    value={field.value ?? ''}
+                    onChange={(v: string) => field.onChange(v || undefined)}
+                    options={[
+                      { value: '', label: '直连（无跳板）' },
+                      ...((hosts.data ?? [])
+                        .filter((h: Host) => h.id !== editing?.id)
+                        .map((h: Host) => ({ value: h.name, label: h.name }))),
+                    ]}
+                  />
+                )}
+              />
+            )}
+          </Field>
+          <div className="sm:col-span-3" />
+
           {/* 开关不是会报错的字段，改用一块 surface-2 行：说明与控件同一行，也给表单收了个尾 */}
           <Controller
             name="monitor_enabled"
@@ -472,4 +501,3 @@ export function HostsPage() {
       />
     </PageTransition>
   )
-}


### PR DESCRIPTION
## 更新

注意到原仓库已在最新 commit 中原生实现了多级跳板主机连接功能（`feat(ssh): ✨ 支持多级跳板主机连接`），本 PR 的功能目标已被上游覆盖。

关闭此 PR，后续可直接使用原仓库的官方实现。

感谢作者的开源工作！