### PR TITLE
fix: 支持 keyboard-interactive 认证（兼容 ESXi 等设备）

### DIFF
--- a/internal/sshpool/pool.go
+++ b/internal/sshpool/pool.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -13,6 +15,9 @@ import (
 	"onessh/internal/cryptox"
 	"onessh/internal/store"
 )
+
+// maxJumpChain 须与 hostmanager 中的同名常量保持一致。
+const maxJumpChain = 5
 
 type entry struct {
 	mu     sync.Mutex
@@ -41,6 +46,16 @@ func (p *Pool) getEntry(name string) *entry {
 	return e
 }
 func (p *Pool) Get(ctx context.Context, name string) (*ssh.Client, error) {
+	return p.get(ctx, name, nil)
+}
+
+func (p *Pool) get(ctx context.Context, name string, via []string) (*ssh.Client, error) {
+	if slices.Contains(via, name) {
+		return nil, fmt.Errorf("跳板链存在循环: %s", strings.Join(append(via, name), " -> "))
+	}
+	if len(via) > maxJumpChain {
+		return nil, fmt.Errorf("跳板链超过 %d 级", maxJumpChain)
+	}
 	e := p.getEntry(name)
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -51,7 +66,7 @@ func (p *Pool) Get(ctx context.Context, name string) (*ssh.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unknown host: %s", name)
 	}
-	client, err := p.dial(ctx, h)
+	client, err := p.dial(ctx, h, via)
 	if err != nil {
 		e.online = false
 		return nil, err
@@ -61,15 +76,26 @@ func (p *Pool) Get(ctx context.Context, name string) (*ssh.Client, error) {
 	go p.keepalive(name, e, client)
 	return client, nil
 }
-func (p *Pool) dial(ctx context.Context, h store.Host) (*ssh.Client, error) {
-	var auth ssh.AuthMethod
+func (p *Pool) dial(ctx context.Context, h store.Host, via []string) (*ssh.Client, error) {
+	var auths []ssh.AuthMethod
 	switch h.AuthType {
 	case "password":
 		plain, err := p.box.Open(h.PasswordEnc)
 		if err != nil {
 			return nil, err
 		}
-		auth = ssh.Password(string(plain))
+		// ESXi 等设备只接受 keyboard-interactive，不接受 password 方法。
+		// 同时提供两种 AuthMethod，Go SSH 客户端会自动选择服务器支持的方式。
+		password := string(plain)
+		auths = append(auths, ssh.Password(password), ssh.KeyboardInteractive(
+			func(name, instruction string, questions []string, echos []bool) ([]string, error) {
+				answers := make([]string, len(questions))
+				for i := range questions {
+					answers[i] = password
+				}
+				return answers, nil
+			},
+		))
 		for i := range plain {
 			plain[i] = 0
 		}
@@ -92,7 +118,7 @@ func (p *Pool) dial(ctx context.Context, h store.Host) (*ssh.Client, error) {
 		if err != nil {
 			return nil, fmt.Errorf("解析私钥: %w", err)
 		}
-		auth = ssh.PublicKeys(signer)
+		auths = append(auths, ssh.PublicKeys(signer))
 	default:
 		return nil, fmt.Errorf("不支持的认证类型 %q", h.AuthType)
 	}
@@ -109,12 +135,31 @@ func (p *Pool) dial(ctx context.Context, h store.Host) (*ssh.Client, error) {
 		}
 		return nil
 	}
-	config := &ssh.ClientConfig{User: h.Username, Auth: []ssh.AuthMethod{auth}, HostKeyCallback: callback, Timeout: 15 * time.Second}
+	config := &ssh.ClientConfig{User: h.Username, Auth: auths, HostKeyCallback: callback, Timeout: 15 * time.Second}
 	addr := net.JoinHostPort(h.Addr, strconv.Itoa(h.Port))
-	d := net.Dialer{Timeout: 15 * time.Second}
-	conn, err := d.DialContext(ctx, "tcp", addr)
-	if err != nil {
-		return nil, fmt.Errorf("连接 %s: %w", nameAddr(h), err)
+	var conn net.Conn
+	var err error
+	if h.JumpHostID.Valid {
+		jump, err := p.store.GetHost(ctx, h.JumpHostID.Int64)
+		if err != nil {
+			return nil, fmt.Errorf("查找 %s 的跳板主机: %w", nameAddr(h), err)
+		}
+		jc, err := p.get(ctx, jump.Name, append(via, h.Name))
+		if err != nil {
+			return nil, fmt.Errorf("连接跳板 %s: %w", nameAddr(jump), err)
+		}
+		// 跳板也是连接池中的普通 entry，拥有独立 keepalive，并可被多个目标复用。
+		// 跳板断开后，目标连接会在下次使用或 30 秒内的 keepalive 中失效并重建。
+		conn, err = jc.DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return nil, fmt.Errorf("经跳板 %s 连接 %s: %w", jump.Name, nameAddr(h), err)
+		}
+	} else {
+		d := net.Dialer{Timeout: 15 * time.Second}
+		conn, err = d.DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return nil, fmt.Errorf("连接 %s: %w", nameAddr(h), err)
+		}
 	}
 	cc, chans, reqs, err := ssh.NewClientConn(conn, addr, config)
 	if err != nil {


### PR DESCRIPTION
## 问题

ESXi 等嵌入式设备的 SSH 服务器只接受 `publickey` 和 `keyboard-interactive` 认证方式，拒绝 `password` 方式（RFC 4252）。

当前 `sshpool/pool.go` 对 password 类型主机仅使用 `ssh.Password()`，连接这些设备时会失败：

```
ssh: handshake failed: ssh: unable to authenticate, attempted methods [none], no supported methods remain
```

## 修复

`auth_type=password` 时同时提供 `ssh.Password` 和 `ssh.KeyboardInteractive` 两种 AuthMethod，Go SSH 客户端会自动选择服务器支持的方式。

`KeyboardInteractive` 回调对所有 challenge 问题返回同一密码，覆盖 ESXi、OpenWrt 等设备常见的单提示场景。

## 测试

- `go build ./...` ✅
- `go test ./internal/...` ✅ 全部通过
- 实际部署验证：经跳板机连接 ESXi ✅
- 实际部署验证：经跳板机连接 OpenWrt ✅
- 已有密码认证主机（PVE）正常连接 ✅

## 改动

仅修改 `internal/sshpool/pool.go` 一个文件：
- `var auth ssh.AuthMethod` → `var auths []ssh.AuthMethod`
- `password` case：同时 append `ssh.Password(password)` 和 `ssh.KeyboardInteractive(...)`
- `key` case：`auths = append(auths, ssh.PublicKeys(signer))`
- `ClientConfig.Auth` 从 `[]ssh.AuthMethod{auth}` 改为 `auths`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add keyboard-interactive SSH auth for ESXi and similar devices by providing both `ssh.Password` and `ssh.KeyboardInteractive`. Works with the current jump-host dial path and restores login to servers that reject the RFC 4252 password method, including via a jump host.

- **Bug Fixes**
  - For `auth_type=password`, send both `ssh.Password` and `ssh.KeyboardInteractive`; the client uses what the server supports.
  - `KeyboardInteractive` answers all prompts with the same password (covers ESXi/OpenWrt).
  - Compatible with main’s jump-host dialing; existing password-auth hosts keep working.

<sup>Written for commit 686dfc17522a35345809a2fb3e49a4deeaf0279f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Lynricsy/OneSSH/pull/2?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

