### PR TITLE
fix: busy_timeout via DSN _pragma so every pooled connection waits (Fixes #4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,13 @@ jobs:
           CGO_ENABLED: "0"
         run: go build -trimpath -o /tmp/onessh ./cmd/onessh
 
+      - name: Upload linux/amd64 binary (fix-busy-timeout)
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: onessh-linux-amd64
+          path: /tmp/onessh
+          if-no-files-found: error
+
   compatibility:
     name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,6 @@ jobs:
           CGO_ENABLED: "0"
         run: go build -trimpath -o /tmp/onessh ./cmd/onessh
 
-      - name: Upload linux/amd64 binary (fix-busy-timeout)
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
-        with:
-          name: onessh-linux-amd64
-          path: /tmp/onessh
-          if-no-files-found: error
-
   compatibility:
     name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
     runs-on: ubuntu-latest

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -38,11 +38,13 @@ func Open(dataDir string) (*Store, error) {
 	if err := os.MkdirAll(filepath.Join(dataDir, "artifacts"), 0o700); err != nil {
 		return nil, fmt.Errorf("创建数据目录: %w", err)
 	}
-	db, err := sql.Open("sqlite", filepath.Join(dataDir, "onessh.db"))
+	// busy_timeout 必须走 DSN（_pragma），PRAGMA 通过连接池 Exec 只对单个连接生效，
+	// 其他并发连接 busy_timeout=0 会立即 SQLITE_BUSY。
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(dataDir, "onessh.db")+"?_pragma=busy_timeout(5000)")
 	if err != nil {
 		return nil, fmt.Errorf("打开 sqlite: %w", err)
 	}
-	for _, pragma := range []string{"PRAGMA journal_mode=WAL", "PRAGMA busy_timeout=5000", "PRAGMA foreign_keys=ON"} {
+	for _, pragma := range []string{"PRAGMA journal_mode=WAL", "PRAGMA foreign_keys=ON"} {
 		if _, err = db.Exec(pragma); err != nil {
 			db.Close()
 			return nil, fmt.Errorf("设置数据库参数: %w", err)


### PR DESCRIPTION
## Problem

Metrics/monitoring sampling fails continuously with `database is locked (5) (SQLITE_BUSY)` once there is concurrent write load (e.g. multi-host monitoring writes + other requests). In our deployment this spammed from startup and WAL grew to ~4MB.

## Root cause

`internal/store/store.go` `Open()` runs `PRAGMA busy_timeout=5000` via `db.Exec()`. `busy_timeout` is a **per-connection** pragma, so it only applies to the single pooled connection that happened to execute that statement. With `database/sql`'s default `MaxOpenConns=0` (unlimited), concurrent writers get fresh connections with `busy_timeout=0` → immediate `SQLITE_BUSY` instead of waiting.

## Fix

Pass the pragma through the DSN so `modernc.org/sqlite` applies it to every new connection:

```go
db, err := sql.Open("sqlite", "file:"+filepath.Join(dataDir, "onessh.db")+"?_pragma=busy_timeout(5000)")
```

Removed `busy_timeout` from the Exec loop (kept `journal_mode=WAL` and `foreign_keys=ON`).

## Verification

- Deployed the patched build in production (12 hosts, monitoring enabled): `SQLITE_BUSY` count went from continuous (~1/min) to **0** over 30+ minutes; WAL stabilized at ~4MB (checkpoint cycling normally).
- `go test ./...` and `go vet ./...` pass in CI.

## Alternative worth considering

For single-writer setups `db.SetMaxOpenConns(1)` would also eliminate the contention class entirely; the DSN approach keeps concurrency.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set SQLite `busy_timeout` via DSN `_pragma` so it applies to every pooled connection, preventing `SQLITE_BUSY` during concurrent writes (Fixes #4). Removed the per-connection PRAGMA and kept `journal_mode=WAL` and `foreign_keys=ON`.

<sup>Written for commit e79599601ec5db97dd4c3a1597cea35ca4d4965a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Lynricsy/OneSSH/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

