### PR TITLE
fix(store): 为每个 SQLite 连接设置 busy timeout

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -38,15 +38,13 @@ func Open(dataDir string) (*Store, error) {
 	if err := os.MkdirAll(filepath.Join(dataDir, "artifacts"), 0o700); err != nil {
 		return nil, fmt.Errorf("创建数据目录: %w", err)
 	}
-	db, err := sql.Open("sqlite", filepath.Join(dataDir, "onessh.db"))
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(dataDir, "onessh.db")+"?_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)")
 	if err != nil {
 		return nil, fmt.Errorf("打开 sqlite: %w", err)
 	}
-	for _, pragma := range []string{"PRAGMA journal_mode=WAL", "PRAGMA busy_timeout=5000", "PRAGMA foreign_keys=ON"} {
-		if _, err = db.Exec(pragma); err != nil {
-			db.Close()
-			return nil, fmt.Errorf("设置数据库参数: %w", err)
-		}
+	if _, err = db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("设置数据库参数: %w", err)
 	}
 	if err = migrate(db); err != nil {
 		db.Close()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -23,6 +23,87 @@ func TestOpenCreatesSchema(t *testing.T) {
 	}
 }
 
+func TestOpenConfiguresEveryConnection(t *testing.T) {
+	st, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	ctx := context.Background()
+	first, err := st.DB.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	second, err := st.DB.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Close()
+
+	for i, conn := range []*sql.Conn{first, second} {
+		var busyTimeout, foreignKeys int
+		if err = conn.QueryRowContext(ctx, `PRAGMA busy_timeout`).Scan(&busyTimeout); err != nil {
+			t.Fatal(err)
+		}
+		if err = conn.QueryRowContext(ctx, `PRAGMA foreign_keys`).Scan(&foreignKeys); err != nil {
+			t.Fatal(err)
+		}
+		if busyTimeout != 5000 || foreignKeys != 1 {
+			t.Fatalf("连接 %d 的数据库参数异常: busy_timeout=%d foreign_keys=%d", i+1, busyTimeout, foreignKeys)
+		}
+	}
+}
+
+func TestOpenWaitsForConcurrentWriter(t *testing.T) {
+	st, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	ctx := context.Background()
+	first, err := st.DB.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	second, err := st.DB.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Close()
+
+	if _, err = first.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		t.Fatal(err)
+	}
+	defer first.ExecContext(ctx, `ROLLBACK`)
+
+	result := make(chan error, 1)
+	go func() {
+		_, execErr := second.ExecContext(ctx, `INSERT INTO metrics(host_id,ts) VALUES(1,1)`)
+		result <- execErr
+	}()
+
+	select {
+	case err = <-result:
+		t.Fatalf("并发写入未等待锁释放: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if _, err = first.ExecContext(ctx, `ROLLBACK`); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err = <-result:
+		if err != nil {
+			t.Fatalf("锁释放后并发写入失败: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("锁释放后并发写入仍未完成")
+	}
+}
+
 func TestOpenUpgradesLegacyDatabase(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()


### PR DESCRIPTION
## 问题

`PRAGMA busy_timeout` 和 `PRAGMA foreign_keys` 都是连接级配置。此前通过 `db.Exec` 设置，只会影响连接池中的一条物理连接；并发采样创建的新连接仍使用 `busy_timeout=0`，写锁竞争时立即返回 `SQLITE_BUSY`。

## 修复

- 通过 modernc.org/sqlite DSN 的重复 `_pragma` 参数，在每条新连接上设置 `busy_timeout(5000)` 与 `foreign_keys(ON)`
- 保留数据库级 `journal_mode=WAL` 的一次性初始化
- 增加多物理连接参数回归测试
- 增加并发写锁等待行为测试

## 验证

- `go test ./internal/store ./internal/monitor -count=1`
- 临时数据目录启动 OneSSH，`GET /healthz` 返回 `{"ok":true,"version":"dev"}`

Fixes #4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `busy_timeout=5000` and `foreign_keys=ON` for every SQLite connection via the `modernc.org/sqlite` DSN `_pragma` options. This prevents spurious SQLITE_BUSY during write contention and keeps `journal_mode=WAL` initialization unchanged.

- **Bug Fixes**
  - Move PRAGMA config to DSN: `_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)` so all connections inherit settings.
  - Keep one-time `PRAGMA journal_mode=WAL`.
  - Add tests for multi-connection PRAGMA values and concurrent writer wait behavior.

<sup>Written for commit 5f7a8ded0b1eaa478469fc6a626f916a67821666. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Lynricsy/OneSSH/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

