### PR TITLE
fix(exec): terminate remote process on timeout

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -336,6 +336,22 @@ func TestEndToEnd(t *testing.T) {
 			t.Fatalf("cwd 未持久化 %+v", second)
 		}
 	})
+	t.Run("exec timeout terminates remote command", func(t *testing.T) {
+		const marker = "/tmp/onessh-timeout-test"
+		timedOut := decoded[execResult](t, call(t, a, "exec", map[string]any{
+			"host": "ssh1", "command": "rm -f " + marker + "; sleep 2; touch " + marker, "timeout_s": 1,
+		}))
+		if !timedOut.Timeout {
+			t.Fatalf("exec 未按时超时: %+v", timedOut)
+		}
+		time.Sleep(2500 * time.Millisecond)
+		probe := decoded[execResult](t, call(t, a, "exec", map[string]any{
+			"host": "ssh1", "command": "test ! -e " + marker + " || { rm -f " + marker + "; exit 1; }",
+		}))
+		if probe.ExitCode != 0 {
+			t.Fatalf("超时后远端命令仍继续执行: %+v", probe)
+		}
+	})
 	t.Run("large output artifact", func(t *testing.T) {
 		large := decoded[execResult](t, call(t, a, "exec", map[string]any{"host": "ssh1", "command": "seq 1 100000", "max_lines": 200}))
 		if !large.Truncated || large.ArtifactID == "" {

--- a/internal/execx/runner.go
+++ b/internal/execx/runner.go
@@ -288,14 +288,17 @@ func (r *Runner) Run(ctx context.Context, client *ssh.Client, command, cwd strin
 	timedOut := false
 	timer := time.NewTimer(opt.Timeout)
 	defer timer.Stop()
+	// 超时或取消时必须先发 SSH signal；只关闭 channel 不会终止 OpenSSH 的远端进程组。
 	select {
 	case waitErr = <-done:
 	case <-ctx.Done():
 		timedOut = true
+		_ = session.Signal(ssh.SIGKILL)
 		_ = session.Close()
 		waitErr = ctx.Err()
 	case <-timer.C:
 		timedOut = true
+		_ = session.Signal(ssh.SIGKILL)
 		_ = session.Close()
 		waitErr = errors.New("command timeout")
 	}

--- a/internal/execx/runner.go
+++ b/internal/execx/runner.go
@@ -248,6 +248,12 @@ func (w *limitedWriter) captured() []byte {
 	return out
 }
 
+func terminateSession(session *ssh.Session) {
+	// 必须先发 SSH signal；只关闭 channel 不会终止 OpenSSH 的远端进程组。
+	_ = session.Signal(ssh.SIGKILL)
+	_ = session.Close()
+}
+
 func (r *Runner) Run(ctx context.Context, client *ssh.Client, command, cwd string, env map[string]string, opt Options) (Result, error) {
 	if opt.Timeout <= 0 {
 		opt.Timeout = 60 * time.Second
@@ -288,18 +294,15 @@ func (r *Runner) Run(ctx context.Context, client *ssh.Client, command, cwd strin
 	timedOut := false
 	timer := time.NewTimer(opt.Timeout)
 	defer timer.Stop()
-	// 超时或取消时必须先发 SSH signal；只关闭 channel 不会终止 OpenSSH 的远端进程组。
 	select {
 	case waitErr = <-done:
 	case <-ctx.Done():
 		timedOut = true
-		_ = session.Signal(ssh.SIGKILL)
-		_ = session.Close()
+		terminateSession(session)
 		waitErr = ctx.Err()
 	case <-timer.C:
 		timedOut = true
-		_ = session.Signal(ssh.SIGKILL)
-		_ = session.Close()
+		terminateSession(session)
 		waitErr = errors.New("command timeout")
 	}
 	stdoutBytes := stdout.captured()


### PR DESCRIPTION
## Repro
Running `rm -f /tmp/onessh-timeout-test; sleep 2; touch /tmp/onessh-timeout-test` through `exec` with `timeout_s: 1` returned `timeout: true`, but a probe after two seconds found `/tmp/onessh-timeout-test`.

## Cause
`execx.Runner.Run` in `internal/execx/runner.go` handled timeout and request cancellation by calling only `ssh.Session.Close()`. Closing the SSH channel stops local I/O but does not send a signal to the remote OpenSSH session process group, so the shell and its child command could continue.

## Fix
- Send SSH `SIGKILL` before closing the channel on timeout or request cancellation, allowing OpenSSH to terminate the full session process group.
- Add an end-to-end regression case that waits past the delayed `touch` and asserts the marker was never created.

## Verification
In a Docker-based Linux/OpenSSH environment, `go test -count=1 ./internal/execx` passed and `go test -count=1 -tags e2e -run TestEndToEnd -v ./e2e` passed, including `TestEndToEnd/exec_timeout_terminates_remote_command` in 3.55s. `gofmt -d internal/execx/runner.go e2e/e2e_test.go` produced no output.

Fixes #13

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Terminates remote processes on `exec` timeout or cancellation by sending SSH SIGKILL before closing the channel. Previously we only closed the channel, letting the remote shell and its child continue; now OpenSSH kills the session process group.

- Centralizes termination in `internal/execx` via `terminateSession`: always Signal(SIGKILL) then Close for both timeout and context cancel paths.
- Adds an e2e regression that ensures a delayed touch never occurs after timeout.
- Behavior change: remote commands stop on local timeout/cancel; no API changes.

<sup>Written for commit d5bfb16b28850b2224c01cc9d4fe018d22fb33f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Lynricsy/OneSSH/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

