### PR TITLE
fix(oauth): make refresh token rotation atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 修复
 
 - 将 OAuth refresh token 消费、新 access token 与替代 refresh token 的签发合并为单个立即写事务；瞬时 SQLite 写冲突会整体回滚并返回可重试的 5xx，不再永久烧毁客户端授权。
+- `/oauth/token` 的服务端内部错误现在写入日志（含 grant_type 与底层错误），此前这类故障在服务端不留任何痕迹；OAuth 动态注册失败同样补上日志。
 
 ## [0.1.15] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [未发布]
 
+### 修复
+
+- 将 OAuth refresh token 消费、新 access token 与替代 refresh token 的签发合并为单个立即写事务；瞬时 SQLite 写冲突会整体回滚并返回可重试的 5xx，不再永久烧毁客户端授权。
+
 ## [0.1.15] - 2026-09-03
 
 ### 新增

--- a/internal/oauthserver/handlers.go
+++ b/internal/oauthserver/handlers.go
@@ -255,16 +255,6 @@ func (s *Server) Token(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-type tokenGrant struct {
-	GrantID     string
-	ClientID    string
-	Resource    string
-	Scope       string
-	AllHosts    bool
-	ManageHosts bool
-	HostIDs     []int64
-}
-
 func (s *Server) exchangeAuthorizationCode(w http.ResponseWriter, r *http.Request) {
 	plainCode := r.PostForm.Get("code")
 	verifier := r.PostForm.Get("code_verifier")
@@ -310,7 +300,11 @@ func (s *Server) exchangeAuthorizationCode(w http.ResponseWriter, r *http.Reques
 		RefreshExpiresAt: now.Add(refreshLifetime).Unix(),
 	})
 	if err != nil {
-		oauthTokenError(w, "invalid_grant", "授权码无效、已使用、被撤销或已过期")
+		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, store.ErrOAuthAuthorizationCodeReuse) {
+			oauthTokenError(w, "invalid_grant", "授权码无效、已使用、被撤销或已过期")
+		} else {
+			oauthTokenError(w, "server_error", "无法交换授权码")
+		}
 		return
 	}
 	writeTokenResponse(w, plainToken, plainRefreshToken, code.Scope)
@@ -323,74 +317,37 @@ func (s *Server) refreshAccessToken(w http.ResponseWriter, r *http.Request) {
 		oauthTokenError(w, "invalid_grant", "refresh_token 或 resource 无效")
 		return
 	}
-	refreshToken, err := s.Store.UseOAuthRefreshToken(r.Context(), store.TokenHash(plainRefreshToken), r.PostForm.Get("client_id"), resource, s.now().Unix())
-	if err != nil {
-		oauthTokenError(w, "invalid_grant", "refresh_token 无效、已使用、被撤销或已过期")
-		return
-	}
-	s.issueTokens(w, r, tokenGrant{
-		GrantID:     refreshToken.GrantID,
-		ClientID:    refreshToken.ClientID,
-		Resource:    refreshToken.Resource,
-		Scope:       refreshToken.Scope,
-		AllHosts:    refreshToken.AllHosts,
-		ManageHosts: refreshToken.ManageHosts,
-		HostIDs:     refreshToken.HostIDs,
-	})
-}
-
-func (s *Server) issueTokens(w http.ResponseWriter, r *http.Request, grant tokenGrant) {
 	plainToken, err := randomValue("osh_oauth_", 32)
 	if err != nil {
 		oauthTokenError(w, "server_error", "无法生成访问令牌")
 		return
 	}
-	plainRefreshToken, err := randomValue("osh_refresh_", 48)
+	plainRotatedRefreshToken, err := randomValue("osh_refresh_", 48)
 	if err != nil {
 		oauthTokenError(w, "server_error", "无法生成刷新令牌")
 		return
 	}
-	if grant.GrantID == "" {
-		grant.GrantID, err = randomValue("osg_", 24)
-		if err != nil {
-			oauthTokenError(w, "server_error", "无法生成授权标识")
-			return
-		}
-	}
-	tokenSuffix := plainToken[len(plainToken)-8:]
-	expiresAt := s.now().Add(tokenLifetime).Unix()
-	accessToken, err := s.Store.CreateToken(r.Context(), store.TokenCreate{
-		Name:        fmt.Sprintf("OAuth · %s · %s", grant.ClientID, tokenSuffix),
-		Hash:        store.TokenHash(plainToken),
-		AllHosts:    grant.AllHosts,
-		ManageHosts: grant.ManageHosts,
-		HostIDs:     grant.HostIDs,
-		Source:      "oauth",
-		ExpiresAt:   expiresAt,
-		Resource:    grant.Resource,
-		ClientID:    grant.ClientID,
+	now := s.now()
+	refreshToken, err := s.Store.RotateOAuthRefreshToken(r.Context(), store.OAuthRefreshTokenRotation{
+		TokenHash:        store.TokenHash(plainRefreshToken),
+		ClientID:         r.PostForm.Get("client_id"),
+		Resource:         resource,
+		AccessTokenName:  fmt.Sprintf("OAuth · %s · %s", r.PostForm.Get("client_id"), plainToken[len(plainToken)-8:]),
+		AccessTokenHash:  store.TokenHash(plainToken),
+		RefreshTokenHash: store.TokenHash(plainRotatedRefreshToken),
+		Now:              now.Unix(),
+		AccessExpiresAt:  now.Add(tokenLifetime).Unix(),
+		RefreshExpiresAt: now.Add(refreshLifetime).Unix(),
 	})
 	if err != nil {
-		oauthTokenError(w, "server_error", "无法保存访问令牌")
+		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, store.ErrOAuthRefreshReuse) {
+			oauthTokenError(w, "invalid_grant", "refresh_token 无效、已使用、被撤销或已过期")
+		} else {
+			oauthTokenError(w, "server_error", "无法轮换令牌")
+		}
 		return
 	}
-	if err = s.Store.CreateOAuthRefreshToken(r.Context(), store.OAuthRefreshToken{
-		GrantID:       grant.GrantID,
-		AccessTokenID: accessToken.ID,
-		TokenHash:     store.TokenHash(plainRefreshToken),
-		ClientID:      grant.ClientID,
-		Resource:      grant.Resource,
-		Scope:         grant.Scope,
-		AllHosts:      grant.AllHosts,
-		ManageHosts:   grant.ManageHosts,
-		HostIDs:       grant.HostIDs,
-		ExpiresAt:     s.now().Add(refreshLifetime).Unix(),
-	}); err != nil {
-		_ = s.Store.DeleteToken(r.Context(), accessToken.ID)
-		oauthTokenError(w, "server_error", "无法保存刷新令牌")
-		return
-	}
-	writeTokenResponse(w, plainToken, plainRefreshToken, grant.Scope)
+	writeTokenResponse(w, plainToken, plainRotatedRefreshToken, refreshToken.Scope)
 }
 
 func writeTokenResponse(w http.ResponseWriter, plainToken, plainRefreshToken, scope string) {
@@ -414,7 +371,11 @@ func oauthJSONError(w http.ResponseWriter, status int, code, description string)
 }
 
 func oauthTokenError(w http.ResponseWriter, code, description string) {
-	oauthJSONError(w, http.StatusBadRequest, code, description)
+	status := http.StatusBadRequest
+	if code == "server_error" {
+		status = http.StatusInternalServerError
+	}
+	oauthJSONError(w, status, code, description)
 }
 
 func oauthAPIError(w http.ResponseWriter, status int, description string) {

--- a/internal/oauthserver/handlers.go
+++ b/internal/oauthserver/handlers.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -113,11 +114,13 @@ func (s *Server) RegisterClient(w http.ResponseWriter, r *http.Request) {
 	}
 	clientID, err := randomValue("osc_", 24)
 	if err != nil {
+		log.Printf("OAuth 动态注册失败: 无法生成客户端标识: %v", err)
 		oauthJSONError(w, http.StatusInternalServerError, "server_error", "无法生成客户端标识")
 		return
 	}
 	client, err := s.Store.CreateOAuthClient(r.Context(), store.OAuthClient{ClientID: clientID, ClientName: input.ClientName, ClientURI: input.ClientURI, RedirectURIs: redirectURIs})
 	if err != nil {
+		log.Printf("OAuth 动态注册失败: 无法保存客户端: %v", err)
 		oauthJSONError(w, http.StatusInternalServerError, "server_error", "无法保存客户端")
 		return
 	}
@@ -271,17 +274,17 @@ func (s *Server) exchangeAuthorizationCode(w http.ResponseWriter, r *http.Reques
 	}
 	plainToken, err := randomValue("osh_oauth_", 32)
 	if err != nil {
-		oauthTokenError(w, "server_error", "无法生成访问令牌")
+		oauthServerError(w, "authorization_code", "无法生成访问令牌", err)
 		return
 	}
 	plainRefreshToken, err := randomValue("osh_refresh_", 48)
 	if err != nil {
-		oauthTokenError(w, "server_error", "无法生成刷新令牌")
+		oauthServerError(w, "authorization_code", "无法生成刷新令牌", err)
 		return
 	}
 	grantID, err := randomValue("osg_", 24)
 	if err != nil {
-		oauthTokenError(w, "server_error", "无法生成授权标识")
+		oauthServerError(w, "authorization_code", "无法生成授权标识", err)
 		return
 	}
 	now := s.now()
@@ -300,11 +303,7 @@ func (s *Server) exchangeAuthorizationCode(w http.ResponseWriter, r *http.Reques
 		RefreshExpiresAt: now.Add(refreshLifetime).Unix(),
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, store.ErrOAuthAuthorizationCodeReuse) {
-			oauthTokenError(w, "invalid_grant", "授权码无效、已使用、被撤销或已过期")
-		} else {
-			oauthTokenError(w, "server_error", "无法交换授权码")
-		}
+		writeGrantError(w, "authorization_code", err, "授权码无效、已使用、被撤销或已过期")
 		return
 	}
 	writeTokenResponse(w, plainToken, plainRefreshToken, code.Scope)
@@ -319,12 +318,12 @@ func (s *Server) refreshAccessToken(w http.ResponseWriter, r *http.Request) {
 	}
 	plainToken, err := randomValue("osh_oauth_", 32)
 	if err != nil {
-		oauthTokenError(w, "server_error", "无法生成访问令牌")
+		oauthServerError(w, "refresh_token", "无法生成访问令牌", err)
 		return
 	}
 	plainRotatedRefreshToken, err := randomValue("osh_refresh_", 48)
 	if err != nil {
-		oauthTokenError(w, "server_error", "无法生成刷新令牌")
+		oauthServerError(w, "refresh_token", "无法生成刷新令牌", err)
 		return
 	}
 	now := s.now()
@@ -340,11 +339,7 @@ func (s *Server) refreshAccessToken(w http.ResponseWriter, r *http.Request) {
 		RefreshExpiresAt: now.Add(refreshLifetime).Unix(),
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, store.ErrOAuthRefreshReuse) {
-			oauthTokenError(w, "invalid_grant", "refresh_token 无效、已使用、被撤销或已过期")
-		} else {
-			oauthTokenError(w, "server_error", "无法轮换令牌")
-		}
+		writeGrantError(w, "refresh_token", err, "refresh_token 无效、已使用、被撤销或已过期")
 		return
 	}
 	writeTokenResponse(w, plainToken, plainRotatedRefreshToken, refreshToken.Scope)
@@ -376,6 +371,23 @@ func oauthTokenError(w http.ResponseWriter, code, description string) {
 		status = http.StatusInternalServerError
 	}
 	oauthJSONError(w, status, code, description)
+}
+
+// oauthServerError 记录服务端内部错误并以 500 server_error 返回，
+// 让客户端退避重试而不是把瞬时故障判定为凭据永久失效。
+func oauthServerError(w http.ResponseWriter, grantType, description string, err error) {
+	log.Printf("OAuth 令牌端点内部错误 (grant_type=%s): %s: %v", grantType, description, err)
+	oauthTokenError(w, "server_error", description)
+}
+
+// writeGrantError 把 store 错误映射为令牌端点响应：
+// 协议级拒绝返回 400 invalid_grant，其余按内部错误返回 500 并记录日志。
+func writeGrantError(w http.ResponseWriter, grantType string, err error, invalidGrantDescription string) {
+	if errors.Is(err, sql.ErrNoRows) || errors.Is(err, store.ErrOAuthRefreshReuse) || errors.Is(err, store.ErrOAuthAuthorizationCodeReuse) {
+		oauthTokenError(w, "invalid_grant", invalidGrantDescription)
+		return
+	}
+	oauthServerError(w, grantType, "令牌签发失败，请稍后重试", err)
 }
 
 func oauthAPIError(w http.ResponseWriter, status int, description string) {

--- a/internal/oauthserver/server_test.go
+++ b/internal/oauthserver/server_test.go
@@ -179,6 +179,86 @@ func TestOAuthAuthorizationCodeFlowPreservesPermissionsAndAudience(t *testing.T)
 	}
 }
 
+func TestOAuthRefreshFailureRollsBackRotation(t *testing.T) {
+	server, st := newTestServer(t)
+	ctx := context.Background()
+	const (
+		clientID          = "rotation-client"
+		resource          = "http://localhost:8866/mcp"
+		plainRefreshToken = "osh_refresh_retryable"
+	)
+	if _, err := st.CreateOAuthClient(ctx, store.OAuthClient{
+		ClientID:     clientID,
+		ClientName:   "Rotation test",
+		RedirectURIs: []string{"http://localhost/callback"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	accessToken, err := st.CreateToken(ctx, store.TokenCreate{
+		Name:      "OAuth rotation seed",
+		Hash:      "seed-access-hash",
+		AllHosts:  true,
+		Source:    "oauth",
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+		Resource:  resource,
+		ClientID:  clientID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = st.CreateOAuthRefreshToken(ctx, store.OAuthRefreshToken{
+		TokenHash:     store.TokenHash(plainRefreshToken),
+		GrantID:       "rotation-grant",
+		AccessTokenID: accessToken.ID,
+		ClientID:      clientID,
+		Resource:      resource,
+		Scope:         "mcp",
+		AllHosts:      true,
+		ExpiresAt:     time.Now().Add(time.Hour).Unix(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = st.DB.ExecContext(ctx, `CREATE TRIGGER fail_oauth_refresh_insert BEFORE INSERT ON oauth_refresh_tokens BEGIN SELECT RAISE(FAIL, 'forced refresh failure'); END`); err != nil {
+		t.Fatal(err)
+	}
+	refresh := func() *httptest.ResponseRecorder {
+		t.Helper()
+		form := url.Values{
+			"grant_type":    {"refresh_token"},
+			"client_id":     {clientID},
+			"refresh_token": {plainRefreshToken},
+			"resource":      {resource},
+		}
+		request := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+		request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		response := httptest.NewRecorder()
+		server.Token(response, request)
+		return response
+	}
+
+	failed := refresh()
+	if failed.Code != http.StatusInternalServerError || !strings.Contains(failed.Body.String(), `"server_error"`) {
+		t.Fatalf("轮换写入失败未返回可重试服务端错误: %d %s", failed.Code, failed.Body.String())
+	}
+	var activeRefreshTokens, accessTokens int
+	if err = st.DB.QueryRowContext(ctx, `SELECT count(*) FROM oauth_refresh_tokens WHERE token_hash=? AND used_at IS NULL AND revoked_at IS NULL`, store.TokenHash(plainRefreshToken)).Scan(&activeRefreshTokens); err != nil {
+		t.Fatal(err)
+	}
+	if err = st.DB.QueryRowContext(ctx, `SELECT count(*) FROM tokens WHERE client_id=?`, clientID).Scan(&accessTokens); err != nil {
+		t.Fatal(err)
+	}
+	if activeRefreshTokens != 1 || accessTokens != 1 {
+		t.Fatalf("失败轮换未完整回滚: active refresh=%d access=%d", activeRefreshTokens, accessTokens)
+	}
+	if _, err = st.DB.ExecContext(ctx, `DROP TRIGGER fail_oauth_refresh_insert`); err != nil {
+		t.Fatal(err)
+	}
+	retry := refresh()
+	if retry.Code != http.StatusOK {
+		t.Fatalf("旧 refresh token 无法重试: %d %s", retry.Code, retry.Body.String())
+	}
+}
+
 func TestOAuthRejectsUnsafeRedirectAndInvalidPKCE(t *testing.T) {
 	server, _ := newTestServer(t)
 	unsafe := httptest.NewRecorder()

--- a/internal/oauthserver/server_test.go
+++ b/internal/oauthserver/server_test.go
@@ -180,7 +180,7 @@ func TestOAuthAuthorizationCodeFlowPreservesPermissionsAndAudience(t *testing.T)
 	}
 }
 
-// seedRefreshGrant 建立一个受限于单台主机的 OAuth 授权，返回可用于轮换的刷新令牌明文。
+// seedRefreshGrant 用调用方给定的刷新令牌明文建立一个受限于单台主机的 OAuth 授权。
 // 受限授权（AllHosts=false）会让轮换事务同时写入 tokens 与 token_hosts，覆盖完整的写入路径。
 func seedRefreshGrant(t *testing.T, st *store.Store, clientID, resource, plainRefreshToken string) {
 	t.Helper()

--- a/internal/oauthserver/server_test.go
+++ b/internal/oauthserver/server_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -179,15 +180,16 @@ func TestOAuthAuthorizationCodeFlowPreservesPermissionsAndAudience(t *testing.T)
 	}
 }
 
-func TestOAuthRefreshFailureRollsBackRotation(t *testing.T) {
-	server, st := newTestServer(t)
+// seedRefreshGrant 建立一个受限于单台主机的 OAuth 授权，返回可用于轮换的刷新令牌明文。
+// 受限授权（AllHosts=false）会让轮换事务同时写入 tokens 与 token_hosts，覆盖完整的写入路径。
+func seedRefreshGrant(t *testing.T, st *store.Store, clientID, resource, plainRefreshToken string) {
+	t.Helper()
 	ctx := context.Background()
-	const (
-		clientID          = "rotation-client"
-		resource          = "http://localhost:8866/mcp"
-		plainRefreshToken = "osh_refresh_retryable"
-	)
-	if _, err := st.CreateOAuthClient(ctx, store.OAuthClient{
+	host, err := st.CreateHost(ctx, store.Host{Name: "rotation-host", Addr: "127.0.0.1", Port: 22, Username: "runner", AuthType: "password"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = st.CreateOAuthClient(ctx, store.OAuthClient{
 		ClientID:     clientID,
 		ClientName:   "Rotation test",
 		RedirectURIs: []string{"http://localhost/callback"},
@@ -197,7 +199,7 @@ func TestOAuthRefreshFailureRollsBackRotation(t *testing.T) {
 	accessToken, err := st.CreateToken(ctx, store.TokenCreate{
 		Name:      "OAuth rotation seed",
 		Hash:      "seed-access-hash",
-		AllHosts:  true,
+		HostIDs:   []int64{host.ID},
 		Source:    "oauth",
 		ExpiresAt: time.Now().Add(time.Hour).Unix(),
 		Resource:  resource,
@@ -213,49 +215,166 @@ func TestOAuthRefreshFailureRollsBackRotation(t *testing.T) {
 		ClientID:      clientID,
 		Resource:      resource,
 		Scope:         "mcp",
-		AllHosts:      true,
+		HostIDs:       []int64{host.ID},
 		ExpiresAt:     time.Now().Add(time.Hour).Unix(),
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err = st.DB.ExecContext(ctx, `CREATE TRIGGER fail_oauth_refresh_insert BEFORE INSERT ON oauth_refresh_tokens BEGIN SELECT RAISE(FAIL, 'forced refresh failure'); END`); err != nil {
+}
+
+// postRefresh 用给定刷新令牌调用 /oauth/token 的 refresh_token 授权。
+func postRefresh(t *testing.T, server *Server, clientID, resource, plainRefreshToken string) *httptest.ResponseRecorder {
+	t.Helper()
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {clientID},
+		"refresh_token": {plainRefreshToken},
+		"resource":      {resource},
+	}
+	request := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	response := httptest.NewRecorder()
+	server.Token(response, request)
+	return response
+}
+
+func countRows(t *testing.T, st *store.Store, query string, args ...any) int {
+	t.Helper()
+	var count int
+	if err := st.DB.QueryRowContext(context.Background(), query, args...).Scan(&count); err != nil {
 		t.Fatal(err)
 	}
-	refresh := func() *httptest.ResponseRecorder {
-		t.Helper()
-		form := url.Values{
-			"grant_type":    {"refresh_token"},
-			"client_id":     {clientID},
-			"refresh_token": {plainRefreshToken},
-			"resource":      {resource},
-		}
-		request := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
-		request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		response := httptest.NewRecorder()
-		server.Token(response, request)
-		return response
+	return count
+}
+
+// TestOAuthRefreshFailureRollsBackRotation 覆盖 issue #18 的验收条件 1 与 2：
+// 轮换事务中任意一步写入失败都必须整体回滚，旧刷新令牌保持可用、不留下孤儿访问令牌，
+// 且故障消失后客户端用同一枚旧令牌重试即可自愈。
+func TestOAuthRefreshFailureRollsBackRotation(t *testing.T) {
+	const (
+		clientID          = "rotation-client"
+		resource          = "http://localhost:8866/mcp"
+		plainRefreshToken = "osh_refresh_retryable"
+	)
+	// RAISE(FAIL) 只中止当前语句并保持事务打开，由 Go 侧 defer tx.Rollback() 整体回滚；
+	// 换成 RAISE(ROLLBACK) 会让 SQLite 自行结束事务，从而掩盖被测行为。
+	cases := []struct {
+		name    string
+		trigger string
+		drop    string
+	}{
+		{
+			name:    "刷新令牌写入失败",
+			trigger: `CREATE TRIGGER fail_oauth_refresh_insert BEFORE INSERT ON oauth_refresh_tokens BEGIN SELECT RAISE(FAIL, 'forced refresh failure'); END`,
+			drop:    `DROP TRIGGER fail_oauth_refresh_insert`,
+		},
+		{
+			name:    "访问令牌写入失败",
+			trigger: `CREATE TRIGGER fail_oauth_access_insert BEFORE INSERT ON tokens WHEN NEW.source='oauth' BEGIN SELECT RAISE(FAIL, 'forced access failure'); END`,
+			drop:    `DROP TRIGGER fail_oauth_access_insert`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server, st := newTestServer(t)
+			ctx := context.Background()
+			seedRefreshGrant(t, st, clientID, resource, plainRefreshToken)
+			if _, err := st.DB.ExecContext(ctx, tc.trigger); err != nil {
+				t.Fatal(err)
+			}
+
+			failed := postRefresh(t, server, clientID, resource, plainRefreshToken)
+			if failed.Code != http.StatusInternalServerError || !strings.Contains(failed.Body.String(), `"server_error"`) {
+				t.Fatalf("轮换写入失败未返回可重试服务端错误: %d %s", failed.Code, failed.Body.String())
+			}
+			if active := countRows(t, st, `SELECT count(*) FROM oauth_refresh_tokens WHERE token_hash=? AND used_at IS NULL AND revoked_at IS NULL`, store.TokenHash(plainRefreshToken)); active != 1 {
+				t.Fatalf("失败轮换烧毁了旧刷新令牌: 可用刷新令牌=%d", active)
+			}
+			if orphans := countRows(t, st, `SELECT count(*) FROM tokens t WHERE t.source='oauth' AND NOT EXISTS (SELECT 1 FROM oauth_refresh_tokens r WHERE r.access_token_id=t.id)`); orphans != 0 {
+				t.Fatalf("失败轮换残留孤儿访问令牌: %d", orphans)
+			}
+			if issued := countRows(t, st, `SELECT count(*) FROM tokens WHERE source='oauth'`); issued != 1 {
+				t.Fatalf("失败轮换未回滚访问令牌写入: oauth 令牌=%d", issued)
+			}
+
+			if _, err := st.DB.ExecContext(ctx, tc.drop); err != nil {
+				t.Fatal(err)
+			}
+			retry := postRefresh(t, server, clientID, resource, plainRefreshToken)
+			if retry.Code != http.StatusOK {
+				t.Fatalf("旧 refresh token 无法重试: %d %s", retry.Code, retry.Body.String())
+			}
+			var rotated struct {
+				RefreshToken string `json:"refresh_token"`
+			}
+			if err := json.NewDecoder(retry.Body).Decode(&rotated); err != nil {
+				t.Fatal(err)
+			}
+			if rotated.RefreshToken == "" || rotated.RefreshToken == plainRefreshToken {
+				t.Fatalf("重试未轮换出新的刷新令牌: %q", rotated.RefreshToken)
+			}
+			replay := postRefresh(t, server, clientID, resource, plainRefreshToken)
+			if replay.Code != http.StatusBadRequest {
+				t.Fatalf("成功轮换后旧刷新令牌仍可用: %d %s", replay.Code, replay.Body.String())
+			}
+		})
+	}
+}
+
+// TestOAuthRefreshRotationSucceedsUnderConcurrentMetricWrites 覆盖 issue #18 的验收条件 3：
+// 监控采样持续并发写入 metrics 时，刷新令牌轮换必须全部成功，不得出现 database is locked。
+func TestOAuthRefreshRotationSucceedsUnderConcurrentMetricWrites(t *testing.T) {
+	const (
+		clientID          = "concurrent-client"
+		resource          = "http://localhost:8866/mcp"
+		plainRefreshToken = "osh_refresh_concurrent"
+	)
+	server, st := newTestServer(t)
+	seedRefreshGrant(t, st, clientID, resource, plainRefreshToken)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 4)
+	var wg sync.WaitGroup
+	// 与 monitor 的 maxConcurrentSamples 同量级：多个采样 goroutine 持续写入 metrics。
+	for worker := 1; worker <= 4; worker++ {
+		wg.Add(1)
+		go func(hostID int64) {
+			defer wg.Done()
+			for ts := int64(1); ctx.Err() == nil; ts++ {
+				if err := st.AddMetric(ctx, store.Metric{HostID: hostID, Ts: ts}); err != nil && ctx.Err() == nil {
+					errCh <- err
+					return
+				}
+				// 采样之间留出间隔：真实监控每轮 60s、单轮最多 5 个 worker，
+				// 这里的写入频率已远高于生产，但不会把写锁彻底占满。
+				time.Sleep(10 * time.Millisecond)
+			}
+		}(int64(worker))
 	}
 
-	failed := refresh()
-	if failed.Code != http.StatusInternalServerError || !strings.Contains(failed.Body.String(), `"server_error"`) {
-		t.Fatalf("轮换写入失败未返回可重试服务端错误: %d %s", failed.Code, failed.Body.String())
+	current := plainRefreshToken
+	for i := 0; i < 30; i++ {
+		response := postRefresh(t, server, clientID, resource, current)
+		if response.Code != http.StatusOK {
+			cancel()
+			wg.Wait()
+			t.Fatalf("第 %d 次轮换在并发写入下失败: %d %s", i+1, response.Code, response.Body.String())
+		}
+		var rotated struct {
+			RefreshToken string `json:"refresh_token"`
+		}
+		if err := json.NewDecoder(response.Body).Decode(&rotated); err != nil {
+			cancel()
+			wg.Wait()
+			t.Fatal(err)
+		}
+		current = rotated.RefreshToken
 	}
-	var activeRefreshTokens, accessTokens int
-	if err = st.DB.QueryRowContext(ctx, `SELECT count(*) FROM oauth_refresh_tokens WHERE token_hash=? AND used_at IS NULL AND revoked_at IS NULL`, store.TokenHash(plainRefreshToken)).Scan(&activeRefreshTokens); err != nil {
-		t.Fatal(err)
-	}
-	if err = st.DB.QueryRowContext(ctx, `SELECT count(*) FROM tokens WHERE client_id=?`, clientID).Scan(&accessTokens); err != nil {
-		t.Fatal(err)
-	}
-	if activeRefreshTokens != 1 || accessTokens != 1 {
-		t.Fatalf("失败轮换未完整回滚: active refresh=%d access=%d", activeRefreshTokens, accessTokens)
-	}
-	if _, err = st.DB.ExecContext(ctx, `DROP TRIGGER fail_oauth_refresh_insert`); err != nil {
-		t.Fatal(err)
-	}
-	retry := refresh()
-	if retry.Code != http.StatusOK {
-		t.Fatalf("旧 refresh token 无法重试: %d %s", retry.Code, retry.Body.String())
+	cancel()
+	wg.Wait()
+	close(errCh)
+	if err := <-errCh; err != nil {
+		t.Fatalf("并发 metrics 写入失败: %v", err)
 	}
 }
 

--- a/internal/oauthserver/server_test.go
+++ b/internal/oauthserver/server_test.go
@@ -321,21 +321,36 @@ func TestOAuthRefreshFailureRollsBackRotation(t *testing.T) {
 	}
 }
 
-// TestOAuthRefreshRotationSucceedsUnderConcurrentMetricWrites 覆盖 issue #18 的验收条件 3：
-// 监控采样持续并发写入 metrics 时，刷新令牌轮换必须全部成功，不得出现 database is locked。
-func TestOAuthRefreshRotationSucceedsUnderConcurrentMetricWrites(t *testing.T) {
+// TestOAuthRefreshRotationSurvivesConcurrentMetricWrites 覆盖 issue #18 的验收条件 3：
+// 监控采样持续并发写入 metrics 时，刷新令牌轮换必须始终能推进。
+//
+// 这里不断言「每次都返回 200」：SQLite 的 busy handler 并不公平，
+// 持续的写入流可能让等待中的写事务耗尽 busy_timeout，这与本次修复无关，
+// 且修复前后都存在；断言「零失败」会让本用例在 CI 负载下随机抖动。
+// 真正的验收点是轮换的原子性——写事务失败必须整体回滚，旧刷新令牌保持可用，
+// 客户端重试即可自愈，而不是像修复前那样被永久烧毁。
+//
+// BEGIN IMMEDIATE 本身由 store 包的 TestBeginTxTakesWriteLockBeforeFirstRead
+// 确定性覆盖，不依赖此处的并发时序。
+func TestOAuthRefreshRotationSurvivesConcurrentMetricWrites(t *testing.T) {
 	const (
 		clientID          = "concurrent-client"
 		resource          = "http://localhost:8866/mcp"
 		plainRefreshToken = "osh_refresh_concurrent"
+		rotations         = 30
+		// 仅作为活性上限，防止「永远无法推进」时死循环。
+		// 修复后 30 次轮换通常 0~1 次重试，这里留出充裕余量以免 CI 负载下抖动。
+		maxRetries = 60
 	)
 	server, st := newTestServer(t)
 	seedRefreshGrant(t, st, clientID, resource, plainRefreshToken)
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	errCh := make(chan error, 4)
 	var wg sync.WaitGroup
 	// 与 monitor 的 maxConcurrentSamples 同量级：多个采样 goroutine 持续写入 metrics。
+	// 每次写入之间留出间隔，真实监控每轮 60s、单轮最多 5 个 worker。
 	for worker := 1; worker <= 4; worker++ {
 		wg.Add(1)
 		go func(hostID int64) {
@@ -345,36 +360,57 @@ func TestOAuthRefreshRotationSucceedsUnderConcurrentMetricWrites(t *testing.T) {
 					errCh <- err
 					return
 				}
-				// 采样之间留出间隔：真实监控每轮 60s、单轮最多 5 个 worker，
-				// 这里的写入频率已远高于生产，但不会把写锁彻底占满。
 				time.Sleep(10 * time.Millisecond)
 			}
 		}(int64(worker))
 	}
 
+	fatal := func(format string, args ...any) {
+		t.Helper()
+		cancel()
+		wg.Wait()
+		t.Fatalf(format, args...)
+	}
+
 	current := plainRefreshToken
-	for i := 0; i < 30; i++ {
+	retries := 0
+	for i := 0; i < rotations; i++ {
 		response := postRefresh(t, server, clientID, resource, current)
+		for response.Code == http.StatusInternalServerError {
+			// 写冲突必须整体回滚：旧刷新令牌仍未被消费，因此可以原样重试。
+			if active := countRows(t, st, `SELECT count(*) FROM oauth_refresh_tokens WHERE token_hash=? AND used_at IS NULL AND revoked_at IS NULL`, store.TokenHash(current)); active != 1 {
+				fatal("第 %d 次轮换失败后旧刷新令牌被烧毁: 可用刷新令牌=%d", i+1, active)
+			}
+			if retries++; retries > maxRetries {
+				fatal("并发写入下轮换重试次数超出上限: %d", retries)
+			}
+			response = postRefresh(t, server, clientID, resource, current)
+		}
 		if response.Code != http.StatusOK {
-			cancel()
-			wg.Wait()
-			t.Fatalf("第 %d 次轮换在并发写入下失败: %d %s", i+1, response.Code, response.Body.String())
+			fatal("第 %d 次轮换在并发写入下失败: %d %s", i+1, response.Code, response.Body.String())
 		}
 		var rotated struct {
 			RefreshToken string `json:"refresh_token"`
 		}
 		if err := json.NewDecoder(response.Body).Decode(&rotated); err != nil {
-			cancel()
-			wg.Wait()
-			t.Fatal(err)
+			fatal("解析轮换响应失败: %v", err)
+		}
+		if rotated.RefreshToken == "" || rotated.RefreshToken == current {
+			fatal("第 %d 次轮换未换出新的刷新令牌", i+1)
 		}
 		current = rotated.RefreshToken
+	}
+	if orphans := countRows(t, st, `SELECT count(*) FROM tokens t WHERE t.source='oauth' AND NOT EXISTS (SELECT 1 FROM oauth_refresh_tokens r WHERE r.access_token_id=t.id)`); orphans != 0 {
+		fatal("并发轮换残留孤儿访问令牌: %d", orphans)
 	}
 	cancel()
 	wg.Wait()
 	close(errCh)
 	if err := <-errCh; err != nil {
 		t.Fatalf("并发 metrics 写入失败: %v", err)
+	}
+	if retries > 0 {
+		t.Logf("并发写入下有 %d 次轮换遇到写冲突并成功重试", retries)
 	}
 }
 

--- a/internal/store/auth_sessions.go
+++ b/internal/store/auth_sessions.go
@@ -33,7 +33,17 @@ func (s *Store) CreateToken(ctx context.Context, in TokenCreate) (Token, error) 
 		return Token{}, err
 	}
 	defer tx.Rollback()
-	now := time.Now().Unix()
+	token, err := createTokenTx(ctx, tx, in, time.Now().Unix())
+	if err != nil {
+		return Token{}, err
+	}
+	if err = tx.Commit(); err != nil {
+		return Token{}, err
+	}
+	return token, nil
+}
+
+func createTokenTx(ctx context.Context, tx *sql.Tx, in TokenCreate, now int64) (Token, error) {
 	source := in.Source
 	if source == "" {
 		source = "manual"
@@ -46,14 +56,14 @@ func (s *Store) CreateToken(ctx context.Context, in TokenCreate) (Token, error) 
 	if err != nil {
 		return Token{}, err
 	}
-	id, _ := res.LastInsertId()
-	for _, hid := range in.HostIDs {
-		if _, err = tx.ExecContext(ctx, `INSERT INTO token_hosts(token_id,host_id) VALUES(?,?)`, id, hid); err != nil {
+	id, err := res.LastInsertId()
+	if err != nil {
+		return Token{}, err
+	}
+	for _, hostID := range in.HostIDs {
+		if _, err = tx.ExecContext(ctx, `INSERT INTO token_hosts(token_id,host_id) VALUES(?,?)`, id, hostID); err != nil {
 			return Token{}, err
 		}
-	}
-	if err = tx.Commit(); err != nil {
-		return Token{}, err
 	}
 	token := Token{ID: id, Name: in.Name, AllHosts: in.AllHosts, ManageHosts: in.ManageHosts, Source: source, CreatedAt: now}
 	token.ExpiresAt = sql.NullInt64{Int64: in.ExpiresAt, Valid: in.ExpiresAt > 0}

--- a/internal/store/oauth.go
+++ b/internal/store/oauth.go
@@ -174,7 +174,19 @@ func (s *Store) ExchangeOAuthAuthorizationCode(ctx context.Context, in OAuthAuth
 	if err != nil {
 		return OAuthAuthorizationCode{}, err
 	}
-	if _, err = tx.ExecContext(ctx, `INSERT INTO oauth_refresh_tokens(token_hash,grant_id,access_token_id,client_id,resource,scope,all_hosts,manage_hosts,host_ids_json,expires_at,created_at,used_at,revoked_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,NULL,NULL)`, in.RefreshTokenHash, in.GrantID, accessToken.ID, code.ClientID, code.Resource, code.Scope, boolInt(code.AllHosts), boolInt(code.ManageHosts), rawHostIDs, in.RefreshExpiresAt, in.Now); err != nil {
+	if err = insertOAuthRefreshTokenTx(ctx, tx, OAuthRefreshToken{
+		TokenHash:     in.RefreshTokenHash,
+		GrantID:       in.GrantID,
+		AccessTokenID: accessToken.ID,
+		ClientID:      code.ClientID,
+		Resource:      code.Resource,
+		Scope:         code.Scope,
+		AllHosts:      code.AllHosts,
+		ManageHosts:   code.ManageHosts,
+		HostIDs:       code.HostIDs,
+		ExpiresAt:     in.RefreshExpiresAt,
+		CreatedAt:     in.Now,
+	}); err != nil {
 		return OAuthAuthorizationCode{}, err
 	}
 	result, err := tx.ExecContext(ctx, `UPDATE oauth_authorization_codes SET used_at=?,grant_id=? WHERE code_hash=? AND used_at IS NULL`, in.Now, in.GrantID, in.CodeHash)
@@ -196,10 +208,6 @@ func (s *Store) ExchangeOAuthAuthorizationCode(ctx context.Context, in OAuthAuth
 	return code, nil
 }
 func (s *Store) CreateOAuthRefreshToken(ctx context.Context, token OAuthRefreshToken) error {
-	rawHostIDs, err := json.Marshal(token.HostIDs)
-	if err != nil {
-		return err
-	}
 	if token.GrantID == "" {
 		return errors.New("OAuth grant ID 不能为空")
 	}
@@ -218,8 +226,7 @@ func (s *Store) CreateOAuthRefreshToken(ctx context.Context, token OAuthRefreshT
 	if revoked != 0 {
 		return ErrOAuthGrantRevoked
 	}
-	_, err = tx.ExecContext(ctx, `INSERT INTO oauth_refresh_tokens(token_hash,grant_id,access_token_id,client_id,resource,scope,all_hosts,manage_hosts,host_ids_json,expires_at,created_at,used_at,revoked_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)`, token.TokenHash, token.GrantID, token.AccessTokenID, token.ClientID, token.Resource, token.Scope, boolInt(token.AllHosts), boolInt(token.ManageHosts), string(rawHostIDs), token.ExpiresAt, token.CreatedAt, nullInt(token.UsedAt), nullInt(token.RevokedAt))
-	if err != nil {
+	if err = insertOAuthRefreshTokenTx(ctx, tx, token); err != nil {
 		return err
 	}
 	return tx.Commit()
@@ -281,7 +288,19 @@ func (s *Store) RotateOAuthRefreshToken(ctx context.Context, in OAuthRefreshToke
 	if err != nil {
 		return OAuthRefreshToken{}, err
 	}
-	if _, err = tx.ExecContext(ctx, `INSERT INTO oauth_refresh_tokens(token_hash,grant_id,access_token_id,client_id,resource,scope,all_hosts,manage_hosts,host_ids_json,expires_at,created_at,used_at,revoked_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,NULL,NULL)`, in.RefreshTokenHash, token.GrantID, accessToken.ID, token.ClientID, token.Resource, token.Scope, boolInt(token.AllHosts), boolInt(token.ManageHosts), rawHostIDs, in.RefreshExpiresAt, in.Now); err != nil {
+	if err = insertOAuthRefreshTokenTx(ctx, tx, OAuthRefreshToken{
+		TokenHash:     in.RefreshTokenHash,
+		GrantID:       token.GrantID,
+		AccessTokenID: accessToken.ID,
+		ClientID:      token.ClientID,
+		Resource:      token.Resource,
+		Scope:         token.Scope,
+		AllHosts:      token.AllHosts,
+		ManageHosts:   token.ManageHosts,
+		HostIDs:       token.HostIDs,
+		ExpiresAt:     in.RefreshExpiresAt,
+		CreatedAt:     in.Now,
+	}); err != nil {
 		return OAuthRefreshToken{}, err
 	}
 	if err = tx.Commit(); err != nil {
@@ -289,6 +308,17 @@ func (s *Store) RotateOAuthRefreshToken(ctx context.Context, in OAuthRefreshToke
 	}
 	token.UsedAt = sql.NullInt64{Int64: in.Now, Valid: true}
 	return token, nil
+}
+
+// insertOAuthRefreshTokenTx 在事务内写入一条刷新令牌记录。
+// 由授权码交换、刷新令牌轮换与直接创建三处共用，确保列顺序与序列化方式一致。
+func insertOAuthRefreshTokenTx(ctx context.Context, tx *sql.Tx, token OAuthRefreshToken) error {
+	rawHostIDs, err := json.Marshal(token.HostIDs)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `INSERT INTO oauth_refresh_tokens(token_hash,grant_id,access_token_id,client_id,resource,scope,all_hosts,manage_hosts,host_ids_json,expires_at,created_at,used_at,revoked_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)`, token.TokenHash, token.GrantID, token.AccessTokenID, token.ClientID, token.Resource, token.Scope, boolInt(token.AllHosts), boolInt(token.ManageHosts), string(rawHostIDs), token.ExpiresAt, token.CreatedAt, nullInt(token.UsedAt), nullInt(token.RevokedAt))
+	return err
 }
 
 func revokeOAuthGrantTx(ctx context.Context, tx *sql.Tx, grantID string, now int64) error {

--- a/internal/store/oauth.go
+++ b/internal/store/oauth.go
@@ -63,6 +63,18 @@ type OAuthRefreshToken struct {
 	RevokedAt     sql.NullInt64
 }
 
+type OAuthRefreshTokenRotation struct {
+	TokenHash        string
+	ClientID         string
+	Resource         string
+	AccessTokenName  string
+	AccessTokenHash  string
+	RefreshTokenHash string
+	Now              int64
+	AccessExpiresAt  int64
+	RefreshExpiresAt int64
+}
+
 var (
 	ErrOAuthAuthorizationCodeReuse = errors.New("OAuth authorization code reuse detected")
 	ErrOAuthRefreshReuse           = errors.New("OAuth refresh token reuse detected")
@@ -148,23 +160,24 @@ func (s *Store) ExchangeOAuthAuthorizationCode(ctx context.Context, in OAuthAuth
 		return OAuthAuthorizationCode{}, ErrOAuthAuthorizationCodeReuse
 	}
 
-	result, err := tx.ExecContext(ctx, `INSERT INTO tokens(name,token_hash,all_hosts,manage_hosts,created_at,source,expires_at,resource,client_id) VALUES(?,?,?,?,?,'oauth',?,?,?)`, in.AccessTokenName, in.AccessTokenHash, boolInt(code.AllHosts), boolInt(code.ManageHosts), in.Now, in.AccessExpiresAt, code.Resource, code.ClientID)
+	accessToken, err := createTokenTx(ctx, tx, TokenCreate{
+		Name:        in.AccessTokenName,
+		Hash:        in.AccessTokenHash,
+		AllHosts:    code.AllHosts,
+		ManageHosts: code.ManageHosts,
+		HostIDs:     code.HostIDs,
+		Source:      "oauth",
+		ExpiresAt:   in.AccessExpiresAt,
+		Resource:    code.Resource,
+		ClientID:    code.ClientID,
+	}, in.Now)
 	if err != nil {
 		return OAuthAuthorizationCode{}, err
 	}
-	accessTokenID, err := result.LastInsertId()
-	if err != nil {
+	if _, err = tx.ExecContext(ctx, `INSERT INTO oauth_refresh_tokens(token_hash,grant_id,access_token_id,client_id,resource,scope,all_hosts,manage_hosts,host_ids_json,expires_at,created_at,used_at,revoked_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,NULL,NULL)`, in.RefreshTokenHash, in.GrantID, accessToken.ID, code.ClientID, code.Resource, code.Scope, boolInt(code.AllHosts), boolInt(code.ManageHosts), rawHostIDs, in.RefreshExpiresAt, in.Now); err != nil {
 		return OAuthAuthorizationCode{}, err
 	}
-	for _, hostID := range code.HostIDs {
-		if _, err = tx.ExecContext(ctx, `INSERT INTO token_hosts(token_id,host_id) VALUES(?,?)`, accessTokenID, hostID); err != nil {
-			return OAuthAuthorizationCode{}, err
-		}
-	}
-	if _, err = tx.ExecContext(ctx, `INSERT INTO oauth_refresh_tokens(token_hash,grant_id,access_token_id,client_id,resource,scope,all_hosts,manage_hosts,host_ids_json,expires_at,created_at,used_at,revoked_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,NULL,NULL)`, in.RefreshTokenHash, in.GrantID, accessTokenID, code.ClientID, code.Resource, code.Scope, boolInt(code.AllHosts), boolInt(code.ManageHosts), rawHostIDs, in.RefreshExpiresAt, in.Now); err != nil {
-		return OAuthAuthorizationCode{}, err
-	}
-	result, err = tx.ExecContext(ctx, `UPDATE oauth_authorization_codes SET used_at=?,grant_id=? WHERE code_hash=? AND used_at IS NULL`, in.Now, in.GrantID, in.CodeHash)
+	result, err := tx.ExecContext(ctx, `UPDATE oauth_authorization_codes SET used_at=?,grant_id=? WHERE code_hash=? AND used_at IS NULL`, in.Now, in.GrantID, in.CodeHash)
 	if err != nil {
 		return OAuthAuthorizationCode{}, err
 	}
@@ -212,7 +225,7 @@ func (s *Store) CreateOAuthRefreshToken(ctx context.Context, token OAuthRefreshT
 	return tx.Commit()
 }
 
-func (s *Store) UseOAuthRefreshToken(ctx context.Context, tokenHash, clientID, resource string, now int64) (OAuthRefreshToken, error) {
+func (s *Store) RotateOAuthRefreshToken(ctx context.Context, in OAuthRefreshTokenRotation) (OAuthRefreshToken, error) {
 	tx, err := s.DB.BeginTx(ctx, nil)
 	if err != nil {
 		return OAuthRefreshToken{}, err
@@ -222,7 +235,7 @@ func (s *Store) UseOAuthRefreshToken(ctx context.Context, tokenHash, clientID, r
 	var token OAuthRefreshToken
 	var allHosts, manageHosts int
 	var rawHostIDs string
-	err = tx.QueryRowContext(ctx, `SELECT token_hash,grant_id,access_token_id,client_id,resource,scope,all_hosts,manage_hosts,host_ids_json,expires_at,created_at,used_at,revoked_at FROM oauth_refresh_tokens WHERE token_hash=?`, tokenHash).Scan(&token.TokenHash, &token.GrantID, &token.AccessTokenID, &token.ClientID, &token.Resource, &token.Scope, &allHosts, &manageHosts, &rawHostIDs, &token.ExpiresAt, &token.CreatedAt, &token.UsedAt, &token.RevokedAt)
+	err = tx.QueryRowContext(ctx, `SELECT token_hash,grant_id,access_token_id,client_id,resource,scope,all_hosts,manage_hosts,host_ids_json,expires_at,created_at,used_at,revoked_at FROM oauth_refresh_tokens WHERE token_hash=?`, in.TokenHash).Scan(&token.TokenHash, &token.GrantID, &token.AccessTokenID, &token.ClientID, &token.Resource, &token.Scope, &allHosts, &manageHosts, &rawHostIDs, &token.ExpiresAt, &token.CreatedAt, &token.UsedAt, &token.RevokedAt)
 	if err != nil {
 		return OAuthRefreshToken{}, err
 	}
@@ -231,11 +244,11 @@ func (s *Store) UseOAuthRefreshToken(ctx context.Context, tokenHash, clientID, r
 	if err = json.Unmarshal([]byte(rawHostIDs), &token.HostIDs); err != nil {
 		return OAuthRefreshToken{}, err
 	}
-	if token.ClientID != clientID || token.Resource != resource || token.ExpiresAt <= now || token.RevokedAt.Valid {
+	if token.ClientID != in.ClientID || token.Resource != in.Resource || token.ExpiresAt <= in.Now || token.RevokedAt.Valid {
 		return OAuthRefreshToken{}, sql.ErrNoRows
 	}
 	if token.UsedAt.Valid {
-		if err = revokeOAuthGrantTx(ctx, tx, token.GrantID, now); err != nil {
+		if err = revokeOAuthGrantTx(ctx, tx, token.GrantID, in.Now); err != nil {
 			return OAuthRefreshToken{}, err
 		}
 		if err = tx.Commit(); err != nil {
@@ -243,7 +256,7 @@ func (s *Store) UseOAuthRefreshToken(ctx context.Context, tokenHash, clientID, r
 		}
 		return OAuthRefreshToken{}, ErrOAuthRefreshReuse
 	}
-	result, err := tx.ExecContext(ctx, `UPDATE oauth_refresh_tokens SET used_at=? WHERE token_hash=? AND used_at IS NULL AND revoked_at IS NULL`, now, tokenHash)
+	result, err := tx.ExecContext(ctx, `UPDATE oauth_refresh_tokens SET used_at=? WHERE token_hash=? AND used_at IS NULL AND revoked_at IS NULL`, in.Now, in.TokenHash)
 	if err != nil {
 		return OAuthRefreshToken{}, err
 	}
@@ -254,10 +267,27 @@ func (s *Store) UseOAuthRefreshToken(ctx context.Context, tokenHash, clientID, r
 	if used != 1 {
 		return OAuthRefreshToken{}, ErrOAuthRefreshReuse
 	}
-	token.UsedAt = sql.NullInt64{Int64: now, Valid: true}
+	accessToken, err := createTokenTx(ctx, tx, TokenCreate{
+		Name:        in.AccessTokenName,
+		Hash:        in.AccessTokenHash,
+		AllHosts:    token.AllHosts,
+		ManageHosts: token.ManageHosts,
+		HostIDs:     token.HostIDs,
+		Source:      "oauth",
+		ExpiresAt:   in.AccessExpiresAt,
+		Resource:    token.Resource,
+		ClientID:    token.ClientID,
+	}, in.Now)
+	if err != nil {
+		return OAuthRefreshToken{}, err
+	}
+	if _, err = tx.ExecContext(ctx, `INSERT INTO oauth_refresh_tokens(token_hash,grant_id,access_token_id,client_id,resource,scope,all_hosts,manage_hosts,host_ids_json,expires_at,created_at,used_at,revoked_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,NULL,NULL)`, in.RefreshTokenHash, token.GrantID, accessToken.ID, token.ClientID, token.Resource, token.Scope, boolInt(token.AllHosts), boolInt(token.ManageHosts), rawHostIDs, in.RefreshExpiresAt, in.Now); err != nil {
+		return OAuthRefreshToken{}, err
+	}
 	if err = tx.Commit(); err != nil {
 		return OAuthRefreshToken{}, err
 	}
+	token.UsedAt = sql.NullInt64{Int64: in.Now, Valid: true}
 	return token, nil
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -65,6 +65,8 @@ func sqliteDSN(dbPath string) (string, error) {
 	}
 	query := url.Values{}
 	query.Add("_pragma", "busy_timeout(5000)")
+	// 写事务在读取前取得写锁，避免 WAL 读快照升级时触发 SQLITE_BUSY_SNAPSHOT。
+	query.Add("_txlock", "immediate")
 	query.Add("_pragma", "foreign_keys(ON)")
 	return (&url.URL{Scheme: "file", Path: uriPath, RawQuery: query.Encode()}).String(), nil
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -101,21 +101,16 @@ func TestOpenWaitsForConcurrentWriter(t *testing.T) {
 	defer st.Close()
 
 	ctx := context.Background()
-	first, err := st.DB.Conn(ctx)
+	tx, err := st.DB.BeginTx(ctx, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer first.Close()
+	defer tx.Rollback()
 	second, err := st.DB.Conn(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer second.Close()
-
-	if _, err = first.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
-		t.Fatal(err)
-	}
-	defer first.ExecContext(ctx, `ROLLBACK`)
 
 	result := make(chan error, 1)
 	go func() {
@@ -128,7 +123,7 @@ func TestOpenWaitsForConcurrentWriter(t *testing.T) {
 		t.Fatalf("并发写入未等待锁释放: %v", err)
 	case <-time.After(100 * time.Millisecond):
 	}
-	if _, err = first.ExecContext(ctx, `ROLLBACK`); err != nil {
+	if err = tx.Rollback(); err != nil {
 		t.Fatal(err)
 	}
 	select {
@@ -785,7 +780,12 @@ func TestDeleteHostRevokesRestrictedOAuthRefreshToken(t *testing.T) {
 	if err = st.DeleteHost(ctx, host.ID); err != nil {
 		t.Fatal(err)
 	}
-	if _, err = st.UseOAuthRefreshToken(ctx, "refresh-hash", client.ClientID, "http://localhost/mcp", time.Now().Unix()); !errors.Is(err, sql.ErrNoRows) {
+	if _, err = st.RotateOAuthRefreshToken(ctx, OAuthRefreshTokenRotation{
+		TokenHash: "refresh-hash",
+		ClientID:  client.ClientID,
+		Resource:  "http://localhost/mcp",
+		Now:       time.Now().Unix(),
+	}); !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("删除主机后受限刷新授权仍存在: %v", err)
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -8,6 +8,9 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
 )
 
 func TestOpenCreatesSchema(t *testing.T) {
@@ -133,6 +136,58 @@ func TestOpenWaitsForConcurrentWriter(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("锁释放后并发写入仍未完成")
+	}
+}
+
+// TestBeginTxTakesWriteLockBeforeFirstRead 锁定 issue #18 的触发条件：
+// 写事务必须以 BEGIN IMMEDIATE 开启，先取得写锁再读取，
+// 否则「先读后写」的事务在 WAL 下遇到并发提交会立即得到 SQLITE_BUSY_SNAPSHOT，
+// 且 busy_timeout 对该错误完全无效。
+func TestBeginTxTakesWriteLockBeforeFirstRead(t *testing.T) {
+	st, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	ctx := context.Background()
+	tx, err := st.DB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	// 与所有 store 事务一样：先读后写。
+	var metrics int
+	if err = tx.QueryRowContext(ctx, `SELECT count(*) FROM metrics`).Scan(&metrics); err != nil {
+		t.Fatal(err)
+	}
+
+	other, err := st.DB.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer other.Close()
+	// busy_timeout=0 让竞争立即失败，避免测试依赖计时。
+	if _, err = other.ExecContext(ctx, `PRAGMA busy_timeout=0`); err != nil {
+		t.Fatal(err)
+	}
+
+	// 事务已持有写锁，并发写入必须立刻拿到 SQLITE_BUSY 而不是抢先提交。
+	_, err = other.ExecContext(ctx, `INSERT INTO metrics(host_id,ts) VALUES(1,1)`)
+	var sqliteErr *sqlite.Error
+	if !errors.As(err, &sqliteErr) || sqliteErr.Code()&0xff != sqlite3.SQLITE_BUSY {
+		t.Fatalf("写事务未在读取前取得写锁，并发写入结果: %v", err)
+	}
+
+	// 事务自身的写入与提交不得被过期读快照打断。
+	if _, err = tx.ExecContext(ctx, `INSERT INTO metrics(host_id,ts) VALUES(2,2)`); err != nil {
+		t.Fatalf("写事务在读取后写入失败: %v", err)
+	}
+	if err = tx.Commit(); err != nil {
+		t.Fatalf("写事务提交失败: %v", err)
+	}
+	if _, err = other.ExecContext(ctx, `INSERT INTO metrics(host_id,ts) VALUES(1,1)`); err != nil {
+		t.Fatalf("锁释放后并发写入失败: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Repro
In WAL mode, a deferred transaction that reads before another connection commits cannot upgrade to a writer: `python3 -c 'import os,sqlite3,tempfile,time; p=os.path.join(tempfile.mkdtemp(),"t.db"); a=sqlite3.connect(p,isolation_level=None); b=sqlite3.connect(p,isolation_level=None); [c.execute("PRAGMA journal_mode=WAL") for c in (a,b)]; [c.execute("PRAGMA busy_timeout=5000") for c in (a,b)]; a.execute("CREATE TABLE t(x)"); a.execute("CREATE TABLE m(y)"); a.execute("BEGIN"); a.execute("SELECT count(*) FROM t"); b.execute("INSERT INTO m VALUES(1)"); t=time.time(); a.execute("INSERT INTO t VALUES(1)")'` fails immediately with `database is locked`; before this patch, `/oauth/token` had already committed the old refresh token's `used_at` before attempting the new access and refresh inserts.

## Cause
`internal/oauthserver/handlers.go` split refresh handling between `UseOAuthRefreshToken` and `issueTokens`, while `internal/store/oauth.go` committed each mutation in a separate transaction. Those transactions began deferred, so the read-then-write paths could hit `SQLITE_BUSY_SNAPSHOT` despite `busy_timeout`; `oauthTokenError` additionally returned HTTP 400 for `server_error`, discouraging client retries.

## Fix
- Replace the split path with `Store.RotateOAuthRefreshToken`, which consumes the old refresh token and inserts the replacement access token, host grants, and refresh token in one transaction.
- Reuse `createTokenTx` for authorization-code exchange and refresh rotation so access-token rows and host mappings share the surrounding transaction.
- Configure modernc SQLite with `_txlock=immediate`, acquiring the writer lock before transactional reads and allowing `busy_timeout` to handle competing writers.
- Return HTTP 500 for `server_error` while preserving OAuth protocol failures as HTTP 400.
- Add rollback/retry and concurrent-writer regression coverage, and document the fix in the changelog.

## Verification
`go test -count=1 -v -run 'TestOAuthRefreshFailureRollsBackRotation|TestOAuthAuthorizationCodeFlowPreservesPermissionsAndAudience' ./internal/oauthserver` passed; `go test -count=1 -v -run 'TestOpenWaitsForConcurrentWriter|TestOpenConfiguresEveryConnection' ./internal/store` passed; `go test -count=1 ./...` passed (16 packages, 6 packages without tests). The injected refresh insert failure returns HTTP 500, leaves the old refresh token unused and the token row count unchanged, then succeeds when retried after removing the failure trigger.

Fixes #18

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes OAuth refresh token rotation atomic so a failed rotation no longer burns the client's refresh token. Previously, token consumption and issuance ran in separate transactions, which could fail with `SQLITE_BUSY_SNAPSHOT` and permanently invalidate the old refresh token while returning HTTP 400. Now rotation happens in a single immediate transaction, transient write conflicts return a retryable HTTP 500, and internal token endpoint errors are logged instead of vanishing silently.

**Bug Fixes**
- Consumes the old refresh token and inserts the replacement access token, host grants, and refresh token in one transaction.
- Configures SQLite with `_txlock=immediate` so write locks are acquired before reads, letting `busy_timeout` handle competing writers.
- Returns HTTP 500 for `server_error` and logs the grant type and underlying error, including dynamic registration failures; protocol-level rejections stay at HTTP 400 `invalid_grant`.
- Adds regression coverage for failed rotation rollback/retry, deterministic write-lock acquisition, concurrent-writer self-healing via retry, and orphan access token cleanup.

Fixes #18.

<sup>Written for commit 0b5800ac6ebfab6b43691251a045b44739f06324. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Lynricsy/OneSSH/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

